### PR TITLE
Pager TagHelper update

### DIFF
--- a/CoreWiki/Pages/All.cshtml
+++ b/CoreWiki/Pages/All.cshtml
@@ -1,48 +1,58 @@
 ﻿@page "{PageNumber?}"
-@model CoreWiki.Pages.AllModel
-@{
-    ViewData["Title"] = "All";
-}
+	@model CoreWiki.Pages.AllModel
+		@{
+			ViewData["Title"] = "All";
+		}
 
-<h2>All Articles</h2>
+		<h2>All Articles</h2>
 
-<div class="row justify-content-between no-gutters">
-    <pager class="col-auto mr-auto mt-3" total-pages="Model.TotalPages" current-page="Model.PageNumber"></pager>
-    <form class="col-auto form-inline" method="post">
-        <select asp-for="PageSize" class="form-control-sm text-primary border-primary">
-            <option class="" value="2">2</option>
-            <option class="" value="5">5</option>
-            <option class="" value="10">10</option>
-            <option class="" value="20">20</option>
-        </select>
-        <button class="btn btn-primary btn-sm" type="submit"><</button>
-    </form>
-</div>
+		<pager total-pages="Model.TotalPages" current-page="Model.PageNumber"></pager>
 
-@foreach (var item in Model.Articles)
-{
+		@*<ul class="pagination">
+			@for (var pageNum = 1; pageNum <= Model.TotalPages; pageNum++)
+			{
 
-    <div class="card border border-primary mb-3">
-        <div class="card-header">
-            <h3 class="card-title">
-                <a href="~/@item.Topic">@item.Topic</a>
-            </h3>
-        </div>
-        <div class="card-body">
-            <h6 class="card-subtitle mb-2 text-muted"><span data-value="@item.Published" class="timeStampValue"> @item.Published</span></h6>
+				<li class="page-item @(pageNum == Model.PageNumber ? "active" : "")">
+				@if (pageNum == Model.PageNumber)
+				{
+					<a class="page-link active" href="#">@pageNum</a>
+				}
+				else
+				{
+					<a class="page-link" asp-page="./All" asp-route-PageNumber="@pageNum">@pageNum</a>
+				}
+				</li>
 
-            <a class="card-link" asp-page="./Edit" asp-route-id="@item.Topic">Edit</a>
-            <a class="card-link" asp-page="./Delete" asp-route-id="@item.Topic">Delete</a>
-        </div>
-    </div>
-}
+			}
+		</ul>*@
 
-@section Styles {
-    <style>
-        .pageNumber {
-            margin: 0px 4px;
-        }
-    </style>
-}
+		@foreach (var item in Model.Articles)
+		{
+
+			<div class="card border border-primary mb-3">
+				<div class="card-header">
+					<h3 class="card-title">
+						<a href="~/@item.Topic">@item.Topic</a>
+					</h3>
+				</div>
+				<div class="card-body">
+					<h6 class="card-subtitle mb-2 text-muted"><span data-value="@item.Published" class="timeStampValue"> @item.Published</span></h6>
+
+					<a class="card-link" asp-page="./Edit" asp-route-id="@item.Topic">Edit</a>
+					<a class="card-link" asp-page="./Delete" asp-route-id="@item.Topic">Delete</a>
+
+				</div>
+
+
+			</div>
+		}
+
+		@section Styles {
+			<style>
+				.pageNumber {
+					margin: 0px 4px;
+				}
+			</style>
+		}
 
 

--- a/CoreWiki/Pages/All.cshtml
+++ b/CoreWiki/Pages/All.cshtml
@@ -1,58 +1,48 @@
 ﻿@page "{PageNumber?}"
-	@model CoreWiki.Pages.AllModel
-		@{
-			ViewData["Title"] = "All";
-		}
+@model CoreWiki.Pages.AllModel
+@{
+    ViewData["Title"] = "All";
+}
 
-		<h2>All Articles</h2>
+<h2>All Articles</h2>
 
-		<pager total-pages="Model.TotalPages" current-page="Model.PageNumber"></pager>
+<div class="row justify-content-between no-gutters">
+    <pager class="col-auto mr-auto mt-3" total-pages="Model.TotalPages" current-page="Model.PageNumber"></pager>
+    <form class="col-auto form-inline" method="post">
+        <select asp-for="PageSize" class="form-control-sm text-primary border-primary">
+            <option class="" value="2">2</option>
+            <option class="" value="5">5</option>
+            <option class="" value="10">10</option>
+            <option class="" value="20">20</option>
+        </select>
+        <button class="btn btn-primary btn-sm" type="submit"><</button>
+    </form>
+</div>
 
-		@*<ul class="pagination">
-			@for (var pageNum = 1; pageNum <= Model.TotalPages; pageNum++)
-			{
+@foreach (var item in Model.Articles)
+{
 
-				<li class="page-item @(pageNum == Model.PageNumber ? "active" : "")">
-				@if (pageNum == Model.PageNumber)
-				{
-					<a class="page-link active" href="#">@pageNum</a>
-				}
-				else
-				{
-					<a class="page-link" asp-page="./All" asp-route-PageNumber="@pageNum">@pageNum</a>
-				}
-				</li>
+    <div class="card border border-primary mb-3">
+        <div class="card-header">
+            <h3 class="card-title">
+                <a href="~/@item.Topic">@item.Topic</a>
+            </h3>
+        </div>
+        <div class="card-body">
+            <h6 class="card-subtitle mb-2 text-muted"><span data-value="@item.Published" class="timeStampValue"> @item.Published</span></h6>
 
-			}
-		</ul>*@
+            <a class="card-link" asp-page="./Edit" asp-route-id="@item.Topic">Edit</a>
+            <a class="card-link" asp-page="./Delete" asp-route-id="@item.Topic">Delete</a>
+        </div>
+    </div>
+}
 
-		@foreach (var item in Model.Articles)
-		{
-
-			<div class="card border border-primary mb-3">
-				<div class="card-header">
-					<h3 class="card-title">
-						<a href="~/@item.Topic">@item.Topic</a>
-					</h3>
-				</div>
-				<div class="card-body">
-					<h6 class="card-subtitle mb-2 text-muted"><span data-value="@item.Published" class="timeStampValue"> @item.Published</span></h6>
-
-					<a class="card-link" asp-page="./Edit" asp-route-id="@item.Topic">Edit</a>
-					<a class="card-link" asp-page="./Delete" asp-route-id="@item.Topic">Delete</a>
-
-				</div>
-
-
-			</div>
-		}
-
-		@section Styles {
-			<style>
-				.pageNumber {
-					margin: 0px 4px;
-				}
-			</style>
-		}
+@section Styles {
+    <style>
+        .pageNumber {
+            margin: 0px 4px;
+        }
+    </style>
+}
 
 

--- a/CoreWiki/Pages/All.cshtml
+++ b/CoreWiki/Pages/All.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "{PageNumber?}"
 	@model CoreWiki.Pages.AllModel
 		@{
 			ViewData["Title"] = "All";

--- a/CoreWiki/Pages/All.cshtml.cs
+++ b/CoreWiki/Pages/All.cshtml.cs
@@ -13,6 +13,11 @@ namespace CoreWiki.Pages
 	{
 
 		private readonly ApplicationDbContext _Context;
+
+		[BindProperty]
+		public int PageSize { get; set; } = 5;
+
+
 		private const int _PageSize = 2;
 
 		public AllModel(ApplicationDbContext context)
@@ -31,18 +36,28 @@ namespace CoreWiki.Pages
 
 		public async Task OnGet(int PageNumber = 1)
 		{
-
-			Articles = await _Context.Articles
-				.AsNoTracking()
-				.OrderBy(a => a.Topic)
-				.Skip((PageNumber - 1) * _PageSize)
-				.Take(_PageSize)
-				.ToArrayAsync();
-
-			TotalPages = (int)Math.Ceiling((await _Context.Articles.CountAsync()) / (double)_PageSize);
+			await FetchArticles();
 
 		}
 
+		public async Task OnPost()
+		{
+			await FetchArticles();
+		}
+
+
+		private async Task FetchArticles()
+		{
+			Articles = await _Context.Articles
+				.AsNoTracking()
+				.OrderBy(a => a.Topic)
+				.Skip((PageNumber - 1) * PageSize)
+				.Take(PageSize)
+				.ToArrayAsync();
+
+			TotalPages = (int)Math.Ceiling((await _Context.Articles.CountAsync()) / (double)PageSize);
+		}
 
 	}
+
 }

--- a/CoreWiki/Pages/All.cshtml.cs
+++ b/CoreWiki/Pages/All.cshtml.cs
@@ -13,11 +13,6 @@ namespace CoreWiki.Pages
 	{
 
 		private readonly ApplicationDbContext _Context;
-
-		[BindProperty]
-		public int PageSize { get; set; } = 5;
-
-
 		private const int _PageSize = 2;
 
 		public AllModel(ApplicationDbContext context)
@@ -36,28 +31,18 @@ namespace CoreWiki.Pages
 
 		public async Task OnGet(int PageNumber = 1)
 		{
-			await FetchArticles();
 
-		}
-
-		public async Task OnPost()
-		{
-			await FetchArticles();
-		}
-
-
-		private async Task FetchArticles()
-		{
 			Articles = await _Context.Articles
 				.AsNoTracking()
 				.OrderBy(a => a.Topic)
-				.Skip((PageNumber - 1) * PageSize)
-				.Take(PageSize)
+				.Skip((PageNumber - 1) * _PageSize)
+				.Take(_PageSize)
 				.ToArrayAsync();
 
-			TotalPages = (int)Math.Ceiling((await _Context.Articles.CountAsync()) / (double)PageSize);
+			TotalPages = (int)Math.Ceiling((await _Context.Articles.CountAsync()) / (double)_PageSize);
+
 		}
 
-	}
 
+	}
 }

--- a/CoreWiki/Pages/All.cshtml.cs
+++ b/CoreWiki/Pages/All.cshtml.cs
@@ -13,14 +13,14 @@ namespace CoreWiki.Pages
 	{
 
 		private readonly ApplicationDbContext _Context;
-		private const int _PageSize = 20;
+		private const int _PageSize = 2;
 
 		public AllModel(ApplicationDbContext context)
 		{
 			this._Context = context;
 		}
 
-		[FromQuery()]
+		[FromRoute]
 		public int PageNumber { get; set; } = 1;
 
 		public int TotalPages { get; set; }
@@ -29,7 +29,7 @@ namespace CoreWiki.Pages
 		public IEnumerable<Article> Articles { get; set; }
 
 
-		public async Task OnGet()
+		public async Task OnGet(int PageNumber = 1)
 		{
 
 			Articles = await _Context.Articles

--- a/CoreWiki/Pages/_Layout.cshtml
+++ b/CoreWiki/Pages/_Layout.cshtml
@@ -42,32 +42,26 @@
 
 		<script src="~/lib/moment/min/moment.min.js"></script>
 		<environment include="Development">
-            <script src="~/lib/jquery/dist/jquery.js"></script>
-            <script src="~/lib/popper.js/dist/umd/popper.js"></script>
-            <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
+			<script src="~/lib/jquery/dist/jquery.js"></script>
+			<script src="~/lib/bootstrap/js/bootstrap.js"></script>
 			<script defer src="https://use.fontawesome.com/releases/v5.0.9/js/all.js" integrity="sha384-8iPTk2s/jMVj81dnzb/iFR2sdA7u06vHJyyLlAd4snFpCl/SnyUjRrbdJsw1pGIl" crossorigin="anonymous"></script>
 			<script src="~/js/site.js" asp-append-version="true"></script>
 		</environment>
-        <environment exclude="Development">
-            <script src="https://code.jquery.com/jquery-3.3.1.min.js"
-                    asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
-                    asp-fallback-test="window.jQuery"
-                    integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
-                    crossorigin="anonymous">
-            </script>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
-                    asp-fallback-src="~/lib/popper.js/dist/umd/popper.min.js"
-                    asp-fallback-test="Popper"
-                    crossorigin="anonymous">
-            </script>
-            <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"
-                    asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
-                    asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"
-                    integrity="sha384-uefMccjFJAIv6A+rW+L4AHf99KvxDjWSu1z9VI8SKNVmz4sk7buKt/6v9KI65qnm"
-                    crossorigin="anonymous">
-            </script>
-            <script src="~/js/site.min.js" asp-append-version="true"></script>
-        </environment>
+		<environment exclude="Development">
+				<script src="https://ajax.aspnetcdn.com/ajax/jquery/jquery-2.2.0.min.js"
+								asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
+								asp-fallback-test="window.jQuery"
+								crossorigin="anonymous"
+								integrity="sha384-K+ctZQ+LL8q6tP7I94W+qzQsfRV2a+AfHIi9k8z8l9ggpc8X+Ytst4yBo/hH+8Fk">
+				</script>
+				<script src="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/bootstrap.min.js"
+								asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
+								asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"
+								crossorigin="anonymous"
+								integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa">
+				</script>
+				<script src="~/js/site.min.js" asp-append-version="true"></script>
+		</environment>
 
 		@RenderSection("Scripts", required: false)
 </body>

--- a/CoreWiki/Pages/_Layout.cshtml
+++ b/CoreWiki/Pages/_Layout.cshtml
@@ -42,26 +42,32 @@
 
 		<script src="~/lib/moment/min/moment.min.js"></script>
 		<environment include="Development">
-			<script src="~/lib/jquery/dist/jquery.js"></script>
-			<script src="~/lib/bootstrap/js/bootstrap.js"></script>
+            <script src="~/lib/jquery/dist/jquery.js"></script>
+            <script src="~/lib/popper.js/dist/umd/popper.js"></script>
+            <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
 			<script defer src="https://use.fontawesome.com/releases/v5.0.9/js/all.js" integrity="sha384-8iPTk2s/jMVj81dnzb/iFR2sdA7u06vHJyyLlAd4snFpCl/SnyUjRrbdJsw1pGIl" crossorigin="anonymous"></script>
 			<script src="~/js/site.js" asp-append-version="true"></script>
 		</environment>
-		<environment exclude="Development">
-				<script src="https://ajax.aspnetcdn.com/ajax/jquery/jquery-2.2.0.min.js"
-								asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
-								asp-fallback-test="window.jQuery"
-								crossorigin="anonymous"
-								integrity="sha384-K+ctZQ+LL8q6tP7I94W+qzQsfRV2a+AfHIi9k8z8l9ggpc8X+Ytst4yBo/hH+8Fk">
-				</script>
-				<script src="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/bootstrap.min.js"
-								asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
-								asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"
-								crossorigin="anonymous"
-								integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa">
-				</script>
-				<script src="~/js/site.min.js" asp-append-version="true"></script>
-		</environment>
+        <environment exclude="Development">
+            <script src="https://code.jquery.com/jquery-3.3.1.min.js"
+                    asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
+                    asp-fallback-test="window.jQuery"
+                    integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+                    crossorigin="anonymous">
+            </script>
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js"
+                    asp-fallback-src="~/lib/popper.js/dist/umd/popper.min.js"
+                    asp-fallback-test="Popper"
+                    crossorigin="anonymous">
+            </script>
+            <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"
+                    asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
+                    asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"
+                    integrity="sha384-uefMccjFJAIv6A+rW+L4AHf99KvxDjWSu1z9VI8SKNVmz4sk7buKt/6v9KI65qnm"
+                    crossorigin="anonymous">
+            </script>
+            <script src="~/js/site.min.js" asp-append-version="true"></script>
+        </environment>
 
 		@RenderSection("Scripts", required: false)
 </body>

--- a/CoreWiki/TagHelpers/PagerTagHelper.cs
+++ b/CoreWiki/TagHelpers/PagerTagHelper.cs
@@ -22,9 +22,8 @@ namespace CoreWiki.TagHelpers
 			_UrlHelperFactory = urlFactory;
 		}
 
-		public override Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+		public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
 		{
-
 
 			var _urlHelper = _UrlHelperFactory.GetUrlHelper(this.ActionContext);
 
@@ -43,33 +42,38 @@ namespace CoreWiki.TagHelpers
 
 			for (var pageNum = 1; pageNum <= TotalPages; pageNum++)
 			{
-
-				// LI tag
-				output.Content.AppendHtml($"<li class=\"page-item");
+				TagBuilder li = new TagBuilder("li");
+				li.AddCssClass("page-item");
 				if (pageNum == CurrentPage)
 				{
-					output.Content.AppendHtml(" active");
+					li.AddCssClass("active");
 				}
-				output.Content.AppendHtml("\">");
 
-				// A tag
+				TagBuilder a = new TagBuilder("a");
+				a.AddCssClass("page-link");
+				a.InnerHtml.Append($"{pageNum}");
 				if (pageNum == CurrentPage)
 				{
-					output.Content.AppendHtml($"<a class=\"page-link active\" href=\"#\">{pageNum}</a>");
+					a.Attributes.Add("href","#");
 				}
 				else
 				{
 					var routes = new { PageNumber = pageNum };
-					output.Content.AppendHtml($"<a class=\"page-link\" href=\"{_urlHelper.Page("./All", routes)}\">{pageNum}</a>");
+					a.Attributes.Add("href", $"{_urlHelper.Page(AspPage, routes)}");
 				}
+				li.InnerHtml.AppendHtml(a);
 
+
+				output.Content.AppendHtml(li);
 
 			}
 
-			output.Content.AppendHtml("</ul>");
-			return Task.CompletedTask;
+			await base.ProcessAsync(context, output);
+			return;
 
 		}
+
+		public string AspPage { get; set; }
 
 		public int CurrentPage { get; set; }
 

--- a/CoreWiki/TagHelpers/PagerTagHelper.cs
+++ b/CoreWiki/TagHelpers/PagerTagHelper.cs
@@ -13,6 +13,12 @@ using Microsoft.AspNetCore.Razor.TagHelpers;
 namespace CoreWiki.TagHelpers
 {
 
+	/// <summary>
+	/// <see cref="ITagHelper"/> implementation targeting &lt;pager&gt; elements.
+	/// </summary>
+	/// <remarks>
+	/// Generates a bootstrap 4 pagination block.
+	/// </remarks>
 	[HtmlTargetElement("pager")]
 	public class PagerTagHelper : TagHelper
 	{
@@ -73,10 +79,28 @@ namespace CoreWiki.TagHelpers
 
 		}
 
+		/// <summary>
+		/// The name of the page.
+		/// </summary>
+		/// <remarks>
+		/// Can be <c>null</c> if refering to the current page.
+		/// </remarks>
 		public string AspPage { get; set; }
 
-		public int CurrentPage { get; set; }
+		/// <summary>
+		/// The number of the current page.
+		/// </summary>
+		/// <remarks>
+		/// If not specified this will default to <c>1</c>.
+		/// </remarks>
+		public int CurrentPage { get; set; } = 1;
 
+		/// <summary>
+		/// The number of page links to show
+		/// </summary>
+		/// <remarks>
+		/// This is required and can not be <c>null</c>.
+		/// </remarks>
 		public int TotalPages { get; set; }
 
 		/// <summary>

--- a/CoreWiki/TagHelpers/PagerTagHelper.cs
+++ b/CoreWiki/TagHelpers/PagerTagHelper.cs
@@ -42,21 +42,20 @@ namespace CoreWiki.TagHelpers
 				if (pageNum == CurrentPage)
 				{
 					li.AddCssClass("active");
-				}
-
-				TagBuilder a = new TagBuilder("a");
-				a.AddCssClass("page-link");
-				a.InnerHtml.Append($"{pageNum}");
-				if (pageNum == CurrentPage)
-				{
-					a.Attributes.Add("href","#");
+					TagBuilder span1 = new TagBuilder("span");
+					span1.AddCssClass("page-link");
+					span1.InnerHtml.Append($"{pageNum}");
+					li.InnerHtml.AppendHtml(span1);
 				}
 				else
 				{
+					TagBuilder a = new TagBuilder("a");
+					a.AddCssClass("page-link");
+					a.InnerHtml.Append($"{pageNum}");
 					var routes = new { PageNumber = pageNum };
 					a.Attributes.Add("href", $"{_urlHelper.Page(AspPage, routes)}");
+					li.InnerHtml.AppendHtml(a);
 				}
-				li.InnerHtml.AppendHtml(a);
 
 				output.Content.AppendHtml(li);
 

--- a/CoreWiki/TagHelpers/PagerTagHelper.cs
+++ b/CoreWiki/TagHelpers/PagerTagHelper.cs
@@ -16,18 +16,15 @@ namespace CoreWiki.TagHelpers
 	[HtmlTargetElement("pager")]
 	public class PagerTagHelper : TagHelper
 	{
-		private readonly IUrlHelperFactory _UrlHelperFactory;
+		private readonly IHtmlGenerator _Generator;
 
-		public PagerTagHelper(IUrlHelperFactory urlFactory)
+		public PagerTagHelper(IHtmlGenerator generator)
 		{
-			_UrlHelperFactory = urlFactory;
+			_Generator = generator;
 		}
 
 		public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
 		{
-
-			var _urlHelper = _UrlHelperFactory.GetUrlHelper(this.ActionContext);
-
 			output.TagMode = TagMode.StartTagAndEndTag;
 			output.TagName = "ul";
 
@@ -49,11 +46,21 @@ namespace CoreWiki.TagHelpers
 				}
 				else
 				{
-					TagBuilder a = new TagBuilder("a");
+					object route = new { PageNumber = pageNum };
+					TagBuilder a;
+					a = _Generator.GeneratePageLink(
+						ViewContext,
+						linkText: pageNum.ToString(),
+						pageName: AspPage,
+						pageHandler: string.Empty,
+						protocol: string.Empty,
+						hostname: string.Empty,
+						fragment: string.Empty,
+						routeValues: route,
+						htmlAttributes: null
+						);
 					a.AddCssClass("page-link");
-					a.InnerHtml.Append($"{pageNum}");
-					var routes = new { PageNumber = pageNum };
-					a.Attributes.Add("href", $"{_urlHelper.Page(AspPage, routes)}");
+
 					li.InnerHtml.AppendHtml(a);
 				}
 
@@ -72,7 +79,11 @@ namespace CoreWiki.TagHelpers
 
 		public int TotalPages { get; set; }
 
+		/// <summary>
+		/// Gets or sets the <see cref="Rendering.ViewContext"/> for the current request.
+		/// </summary>
+		[HtmlAttributeNotBound]
 		[ViewContext]
-		public ActionContext ActionContext { get; set; }
+		public ViewContext ViewContext { get; set; }
 	}
 }

--- a/CoreWiki/TagHelpers/PagerTagHelper.cs
+++ b/CoreWiki/TagHelpers/PagerTagHelper.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.Runtime.TagHelpers;
 using Microsoft.AspNetCore.Razor.TagHelpers;
@@ -30,15 +31,9 @@ namespace CoreWiki.TagHelpers
 			output.TagMode = TagMode.StartTagAndEndTag;
 			output.TagName = "ul";
 
-
-			if (output.Attributes.ContainsName("class"))
-			{
-				output.Attributes.SetAttribute("class", output.Attributes["class"].Value + " pagination");
-			}
-			else
-			{
-				output.Attributes.Add("class", "pagination");
-			}
+			TagBuilder ul = new TagBuilder("ul");
+			ul.AddCssClass("pagination");
+			output.MergeAttributes(ul);
 
 			for (var pageNum = 1; pageNum <= TotalPages; pageNum++)
 			{
@@ -62,7 +57,6 @@ namespace CoreWiki.TagHelpers
 					a.Attributes.Add("href", $"{_urlHelper.Page(AspPage, routes)}");
 				}
 				li.InnerHtml.AppendHtml(a);
-
 
 				output.Content.AppendHtml(li);
 


### PR DESCRIPTION
## TagHelper Update ##
Updates the TagHelper to use the TagBuilder class when making the html nodes. 

- Uses TagBuilder
    - This always provides well-created nodes
    - Use `IHtmlGenerator.GeneratePageLink()` to create the anchor tag instead. This is what the AnchorTagHelper uses. 
- Fixes html node logic (no ending `</li>` tags)
 - Adds summary comments so that you get helper documentation when composing the `<pager>`  tag in a smart editor (like VS)
- Adds `asp-page` as a parameter to the `PagerTagHelper`
    - This replaces the hard-coded `./All` but should never have to be used with the current page. In fact I can't think of a reason to have it, but I left it in anyway to show where it goes in the GeneratePageLink.

## Adds `PageNumber` to the route ##
Instead of passing `PageNumber` through the `querystring` it is now passed through the route (a better ASP.NET Core pattern).

This is achieved in 3 simple steps:
  - Add to the **cshtml** page
```
    @page "{PageNumber?}"
```
  - Add to the **OnGet()** Razor class
```
    OnGet(int PageNumber = 1)
```
  - Decorate the PageNumber property with **[FromRoute]**
```
    [FromRoute]
    public int PageNumber { get; set; }
```