### PR TITLE
Adds Cake & Docker build script, AppVeyor & Travis CI configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,3 +263,10 @@ __pycache__/
 # Omit our lib folders that are being restored from npm
 CoreWiki/wwwroot/lib/
 !CoreWiki/wwwroot/lib/simplemde
+
+# VSCode 
+.vscode/
+
+# Cake files
+[Tt]ools/
+[Oo]utput/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: csharp
+os:
+  - osx
+  - linux
+
+sudo: required
+dist: trusty
+
+osx_image: xcode9.2
+
+mono: none
+dotnet: 2.1.101
+
+script:
+  - ./build.sh --Target=Travis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM cakebuild/cake:2.1-sdk AS builder
+
+RUN apt-get update -qq \
+    && curl -sL https://deb.nodesource.com/setup_9.x | bash - \
+    && apt-get install -y nodejs
+
+ADD .  /src
+
+RUN Cake /src/build.cake --Target=Publish
+
+FROM microsoft/aspnetcore:2.0.6
+
+COPY --from=builder /src/output /app
+
+CMD ["dotnet","/app/CoreWiki.dll"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+# Operating system (build VM template)
+os: Visual Studio 2017
+
+# Build script
+build_script:
+  - ps: .\build.ps1  --target="AppVeyor" --verbosity=Verbose
+
+# Tests
+test: off
+
+init:
+  - git config --global core.autocrlf true

--- a/build.cake
+++ b/build.cake
@@ -1,0 +1,95 @@
+///////////////////////////////////////////////////////////////////////////////
+// ARGUMENTS
+///////////////////////////////////////////////////////////////////////////////
+
+var target = Argument("target", "Default");
+var configuration = Argument("configuration", "Release");
+var npmPath = IsRunningOnWindows()
+                ? Context.Tools.Resolve("npm.cmd")
+                : Context.Tools.Resolve("npm");
+
+//////////////////////////////////////////////////////////////////////
+// PARAMETERS
+//////////////////////////////////////////////////////////////////////
+
+var project = "CoreWiki";
+var solution = $"./{project}.sln";
+var publishPath = MakeAbsolute(Directory("./output"));
+
+//////////////////////////////////////////////////////////////////////
+// HELPERS
+//////////////////////////////////////////////////////////////////////
+
+Action<FilePath, DirectoryPath, ProcessArgumentBuilder> Cmd => (path, workingPath, args) => {
+    var result = StartProcess(
+        path,
+        new ProcessSettings {
+            Arguments = args,
+            WorkingDirectory = workingPath
+        });
+
+    if(0 != result)
+    {
+        throw new Exception($"Failed to execute tool {path.GetFilename()} ({result})");
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// TASKS
+///////////////////////////////////////////////////////////////////////////////
+
+Task("Clean")
+    .Does( () => {
+        CleanDirectories($"./{project}/obj/**/*.*");
+        CleanDirectories($"./{project}/bin/{configuration}/**/*.*");
+});
+
+Task("Clean-Publish")
+    .IsDependentOn("Clean")
+    .Does( () => {
+        CleanDirectory(publishPath);
+});
+
+Task("NPM-Install")
+    .IsDependentOn("Clean")
+    .Does( ()=> {
+    Cmd(npmPath,
+        $"./{project}",
+        new ProcessArgumentBuilder()
+            .Append("install")
+    );
+});
+
+Task("Restore")
+    .IsDependentOn("NPM-Install")
+    .IsDependentOn("Clean")
+    .Does( () => {
+    DotNetCoreRestore(solution);
+});
+
+Task("Build")
+    .IsDependentOn("Restore")
+    .Does( () => {
+    DotNetCoreBuild(solution,
+        new DotNetCoreBuildSettings {
+            NoRestore = true,
+            Configuration = configuration
+        });
+});
+
+Task("Publish")
+    .IsDependentOn("Restore")
+    .IsDependentOn("Clean-Publish")
+    .Does( () => {
+    DotNetCorePublish(solution,
+        new DotNetCorePublishSettings {
+            NoRestore = true,
+            Configuration = configuration,
+            OutputDirectory = publishPath
+        });
+});
+
+Task("Default")
+    .IsDependentOn("Build");
+
+RunTarget(target);

--- a/build.cake
+++ b/build.cake
@@ -95,4 +95,7 @@ Task("Default")
 Task("AppVeyor")
     .IsDependentOn("Publish");
 
+Task("Travis")
+    .IsDependentOn("Build");
+
 RunTarget(target);

--- a/build.cake
+++ b/build.cake
@@ -92,4 +92,7 @@ Task("Publish")
 Task("Default")
     .IsDependentOn("Build");
 
+Task("AppVeyor")
+    .IsDependentOn("Publish");
+
 RunTarget(target);

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,43 @@
+$CakeVersion = "0.26.1"
+
+# Make sure tools folder exists
+$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+$ToolPath = Join-Path $PSScriptRoot "tools"
+if (!(Test-Path $ToolPath)) {
+    Write-Verbose "Creating tools directory..."
+    New-Item -Path $ToolPath -Type directory | out-null
+}
+
+###########################################################################
+# INSTALL CAKE
+###########################################################################
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+Function Unzip
+{
+    param([string]$zipfile, [string]$outpath)
+
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+}
+
+
+# Make sure Cake has been installed.
+$CakePath = Join-Path $ToolPath "Cake.CoreCLR.$CakeVersion"
+$CakeDllPath = Join-Path $CakePath "Cake.dll"
+$CakeZipPath = Join-Path $ToolPath "Cake.zip"
+if (!(Test-Path $CakeDllPath)) {
+    Write-Host "Installing Cake $CakeVersion..."
+     (New-Object System.Net.WebClient).DownloadFile("https://www.nuget.org/api/v2/package/Cake.CoreCLR/$CakeVersion", $CakeZipPath)
+     Unzip $CakeZipPath $CakePath
+     Remove-Item $CakeZipPath
+}
+
+###########################################################################
+# RUN BUILD SCRIPT
+###########################################################################
+& dotnet "$CakeDllPath" ./build.cake --bootstrap
+if ($LASTEXITCODE -eq 0)
+{
+    & dotnet "$CakeDllPath" ./build.cake $args
+}
+exit $LASTEXITCODE

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Define varibles
+CAKE_VERSION=0.26.1
+DOTNET_SDK_VERSION=2.1.4
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+TOOLS_DIR=$SCRIPT_DIR/tools
+CAKE_DLL=$TOOLS_DIR/Cake.CoreCLR.$CAKE_VERSION/Cake.dll
+
+# Make sure the tools folder exist.
+if [ ! -d "$TOOLS_DIR" ]; then
+  mkdir "$TOOLS_DIR"
+fi
+
+###########################################################################
+# INSTALL CAKE
+###########################################################################
+
+if [ ! -f "$CAKE_DLL" ]; then
+    echo "Installing Cake $CAKE_VERSION..."
+    curl -Lsfo Cake.zip "https://www.nuget.org/api/v2/package/Cake.CoreCLR/$CAKE_VERSION" && unzip -q Cake.zip -d "$TOOLS_DIR/Cake.CoreCLR.$CAKE_VERSION" && rm -f Cake.zip
+    if [ $? -ne 0 ]; then
+        echo "An error occured while installing Cake."
+        exit 1
+    fi
+fi
+
+# Make sure that Cake has been installed.
+if [ ! -f "$CAKE_DLL" ]; then
+    echo "Could not find Cake.exe at '$CAKE_DLL'."
+    exit 1
+fi
+
+###########################################################################
+# RUN BUILD SCRIPT
+###########################################################################
+
+# Start Cake
+(exec dotnet "$CAKE_DLL" build.cake --bootstrap) && (exec dotnet "$CAKE_DLL" build.cake "$@")


### PR DESCRIPTION
Currently there seems to be no continuous integration hooked up for this projects, this proposes AppVeyor, Travis CI and Docker hub all orchestrated through the same Cake build script for minimal duplication of build logic. End goal is to have each commit and PR build automatically on multiple environments and operating systems with ease.

### PR Contents

I've Divided PR into 4 commits

1. Adds Cake build script and powershell / bash boostrappers to fetch and execute Cake (bootstrappers currently assume .NET CLI present, but SDK installation could be added in bootstrappers too)
2. Adds AppVeyor yaml file, which instructs how do build the project on AppVeyor (which basically means it should just be a matter for repo/forks of adding project to AppVeyor and it should build)
3. Adds a Docker file, multistage build resulting in a runtime only container
4. Adds TravisCI yaml file, which instructs how do build the project on TravisCI


### Script workflow

The Cake script has a pretty basic workflow
1.	Clean so there’s no old artifacts before build
2.	NPM install  - There’s a NPM addin which adds NPM methods to the Cake DSL, but I went no dependencies in this Case just to show you can in a x-plat way invoke commands, even if Cake doesn’t “know” about them.
3.	NuGet restore
4.	.NET Build or Publish

AppVeyor / Docker / Docker Hub / Travis CI all use the exact same Cake script. I added AppVeyor / Travis targets just as a “best practice”, as I then only need to change build.cake and not the environment / travis / yml files if one would want to change anything in the flow. I.e. on AppVeyor i do a publish build and on travis just a build.
This makes the build definition environment agnostic which I think is really nice.


### Example CI

I've added & tested AppVeyor, TravisCI and Docker Hub on my fork which you can see examples of below, happy to assist setting those up for the main repo

* AppVeyor - https://ci.appveyor.com/project/devlead/corewiki
* TravisCI - https://travis-ci.org/devlead/CoreWiki
* Docker Hub - https://hub.docker.com/r/devlead/corewiki

### Testing locally

If you have the correct .NET Core SDK installed it should just be a matter of

* In PowerShell clone repo and execute `build.ps1` (tested Mac & Windows)
* In Bash clone repo and execute `build.sh` (tested Mac & Linux)
* Docker `docker build .`, currently only tested on Linux containers, but should be pretty easy to port to a Windows container as the `build.cake` will be the same.

Happy to pair if you have any questions. 
