### PR TITLE
Upgrade package.json and _Layout.cshtml to point to Bootstrap 4.1.1

### DIFF
--- a/CoreWiki/Pages/_Layout.cshtml
+++ b/CoreWiki/Pages/_Layout.cshtml
@@ -60,10 +60,10 @@
                     asp-fallback-test="Popper"
                     crossorigin="anonymous">
             </script>
-            <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"
+            <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/js/bootstrap.min.js"
                     asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
                     asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal"
-                    integrity="sha384-uefMccjFJAIv6A+rW+L4AHf99KvxDjWSu1z9VI8SKNVmz4sk7buKt/6v9KI65qnm"
+                    integrity="sha384-smHYKdLADwkXOn1EmN1qk/HfnUcbVRZyYmZ4qpPea6sjB/pTJ0euyQp0Mk8ck+5T"
                     crossorigin="anonymous">
             </script>
             <script src="~/js/site.min.js" asp-append-version="true"></script>

--- a/CoreWiki/package.json
+++ b/CoreWiki/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"description": "",
 	"dependencies": {
-		"bootstrap": "^4.1.0",
+		"bootstrap": "^4.1.1",
 		"jquery": "^3.3.1",
 		"jquery-validation": "^1.17.0",
 		"jquery-validation-unobtrusive": "^3.2.9",


### PR DESCRIPTION
We're using a CDN to point to the production Bootstrap js, so we need to update every time the package changes. One of the downsides of using CDNs
