### PR TITLE
Fix indenting in Startup.cs; Tabs vs spaces in project

### DIFF
--- a/CoreWiki/.editorconfig
+++ b/CoreWiki/.editorconfig
@@ -2,8 +2,8 @@ root = true
 
 [*]
 end_of_line = crlf
-indent_style = tab
-indent_size = 2
+indent_style = space
+indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
 

--- a/CoreWiki/Startup.cs
+++ b/CoreWiki/Startup.cs
@@ -20,85 +20,82 @@ using Microsoft.AspNetCore.Http;
 
 namespace CoreWiki
 {
-  public static class StaticHttpContextExtensions
-  {
-	public static void AddHttpContextAccessor(this IServiceCollection services)
-	{
-	  services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
-	}
-
-	public static IApplicationBuilder UseStaticHttpContext(this IApplicationBuilder app)
-	{
-	  var httpContextAccessor = app.ApplicationServices.GetRequiredService<IHttpContextAccessor>();
-	  WikiHttpContext.HttpContext.Configure(httpContextAccessor);
-	  return app;
-		}
-  }
-  public class Startup
-  {
-  public Startup(IConfiguration configuration)
-  {
-    Configuration = configuration;
-  }
-
-  public IConfiguration Configuration { get; }
-
-  // This method gets called by the runtime. Use this method to add services to the container.
-  public void ConfigureServices(IServiceCollection services)
-  {
-    services.AddRSSFeed<RSSProvider>();
-
-			services.AddEntityFrameworkSqlite()
-				.AddDbContextPool<ApplicationDbContext>(options =>
-						options.UseSqlite("Data Source=./wiki.db")
-				);
-
-    // Add NodaTime clock for time-based testing
-    services.AddSingleton<IClock>(SystemClock.Instance);
-
-    services.AddRouting(options => options.LowercaseUrls = true);
-	  services.AddHttpContextAccessor();
-
-	  services.AddMvc()
-    .AddRazorPagesOptions(options =>
+    public static class StaticHttpContextExtensions
     {
+        public static void AddHttpContextAccessor(this IServiceCollection services)
+        {
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
+        }
 
-      options.Conventions.AddPageRoute("/Details", "{Slug?}");
-      options.Conventions.AddPageRoute("/Details", @"Index");
-    });
-
-  }
-
-  // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-  public void Configure(IApplicationBuilder app, IHostingEnvironment env)
-  {
-    if (env.IsDevelopment())
-    {
-    	app.UseDeveloperExceptionPage();
-    }
-    else
-    {
-    	app.UseExceptionHandler("/Error");
+        public static IApplicationBuilder UseStaticHttpContext(this IApplicationBuilder app)
+        {
+            var httpContextAccessor = app.ApplicationServices.GetRequiredService<IHttpContextAccessor>();
+            WikiHttpContext.HttpContext.Configure(httpContextAccessor);
+            return app;
+        }
     }
 
-    app.UseStaticFiles();
-	  app.UseStaticHttpContext();
-
-    app.UseRSSFeed("/feed", new RSSFeedOptions
+    public class Startup
     {
-			Title = "CoreWiki RSS Feed",
-			Copyright = DateTime.UtcNow.Year.ToString(),
-			Description = "RSS Feed for CoreWiki",
-			Url = new Uri(Configuration["Url"])
-    });
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
 
-    var scope = app.ApplicationServices.CreateScope();
-    var context = scope.ServiceProvider.GetService<ApplicationDbContext>();
+        public IConfiguration Configuration { get; }
 
-    app.UseMvc();
-    ApplicationDbContext.SeedData(context);
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddRSSFeed<RSSProvider>();
 
-  }
+            services.AddEntityFrameworkSqlite()
+                .AddDbContextPool<ApplicationDbContext>(options =>
+                    options.UseSqlite("Data Source=./wiki.db")
+                );
 
-  }
+            // Add NodaTime clock for time-based testing
+            services.AddSingleton<IClock>(SystemClock.Instance);
+
+            services.AddRouting(options => options.LowercaseUrls = true);
+            services.AddHttpContextAccessor();
+
+            services.AddMvc()
+                .AddRazorPagesOptions(options =>
+                {
+                    options.Conventions.AddPageRoute("/Details", "{Slug?}");
+                    options.Conventions.AddPageRoute("/Details", @"Index");
+                });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseExceptionHandler("/Error");
+            }
+
+            app.UseStaticFiles();
+            app.UseStaticHttpContext();
+
+            app.UseRSSFeed("/feed", new RSSFeedOptions
+            {
+                Title = "CoreWiki RSS Feed",
+                Copyright = DateTime.UtcNow.Year.ToString(),
+                Description = "RSS Feed for CoreWiki",
+                Url = new Uri(Configuration["Url"])
+            });
+
+            var scope = app.ApplicationServices.CreateScope();
+            var context = scope.ServiceProvider.GetService<ApplicationDbContext>();
+
+            app.UseMvc();
+            ApplicationDbContext.SeedData(context);
+        }
+    }
 }


### PR DESCRIPTION
I noticed that there was some indenting weirdness happening in `Startup.cs`, specifically with the methods in `StaticHttpContextExtensions` being at the same indent level as the class:

<img width="634" alt="identing" src="https://user-images.githubusercontent.com/13892/40594913-256a7fac-6275-11e8-91de-54ee3af8cf65.png">

So, I ran an auto-formatting tool (JetBrains Rider)  that applies the rules in `.editorconfig`. 

However this led me to discover that `.editorconfig` specifies a 2-**tab** indent. However most of the code is idented with 4 spaces. For example in `Program.cs`:

<img width="457" alt="4space-indent" src="https://user-images.githubusercontent.com/13892/40595161-5747a918-6276-11e8-9343-e3ed405eb095.png">

I'm not trying to start a 'tabs vs spaces' war 😄, however I think it's good practice to keep style consistent. IMO 4-space indent makes the code more readable, however that's just my personal preference.

Maybe someone could create another PR to run a code linter on build / CI?


