### PR TITLE
'Article not found' and 'Page not found' error pages (Issue 13)

### DIFF
--- a/CoreWiki/Helpers/ArticleNotFoundResult.cs
+++ b/CoreWiki/Helpers/ArticleNotFoundResult.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace CoreWiki.Helpers
+{
+	public class ArticleNotFoundResult : ViewResult
+	{
+		public ArticleNotFoundResult()
+		{
+			ViewName = "ArticleNotFound";
+			StatusCode = 404;
+		}
+	}
+}

--- a/CoreWiki/Pages/ArticleNotFound.cshtml
+++ b/CoreWiki/Pages/ArticleNotFound.cshtml
@@ -1,0 +1,7 @@
+@{
+	var title = "Article not found";
+	ViewData["Title"] = title;
+}
+<h1>@title</h1>
+<p>Please check that the URL you entered is correct. It's also possible that an article at this address was deleted.</p>
+<a href="~/">Go to Homepage</a>

--- a/CoreWiki/Pages/Details.cshtml.cs
+++ b/CoreWiki/Pages/Details.cshtml.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using CoreWiki.Models;
 using NodaTime;
+using CoreWiki.Helpers;
 
 namespace CoreWiki.Pages
 {
@@ -33,7 +34,7 @@ namespace CoreWiki.Pages
 
 			if (Article == null)
 			{
-				return NotFound();
+				return new ArticleNotFoundResult();
 			}
 
 			if (Request.Cookies[Article.Topic] == null)
@@ -56,7 +57,7 @@ namespace CoreWiki.Pages
 			Article = await _context.Articles.Include(x => x.Comments).SingleOrDefaultAsync(m => m.Id == comment.IdArticle);
 
 			if (Article == null)
-								 return NotFound();
+								 return new ArticleNotFoundResult();
 
 			if (!ModelState.IsValid)
 								 return Page();

--- a/CoreWiki/Pages/Edit.cshtml.cs
+++ b/CoreWiki/Pages/Edit.cshtml.cs
@@ -31,14 +31,14 @@ namespace CoreWiki.Pages
 		{
 			if (id == null)
 			{
-				return NotFound();
+				return new ArticleNotFoundResult();
 			}
 
 			Article = await _context.Articles.SingleOrDefaultAsync(m => m.Topic == id);
 
 			if (Article == null)
 			{
-				return NotFound();
+				return new ArticleNotFoundResult();
 			}
 			return Page();
 		}
@@ -64,7 +64,7 @@ namespace CoreWiki.Pages
 			{
 				if (!ArticleExists(Article.Topic))
 				{
-					return NotFound();
+					return new ArticleNotFoundResult();
 				}
 				else
 				{

--- a/CoreWiki/Pages/HttpErrors/404.cshtml
+++ b/CoreWiki/Pages/HttpErrors/404.cshtml
@@ -1,0 +1,7 @@
+@page
+@{
+	var title = "Page not found";
+	ViewData["Title"] = title;
+}
+<h1>@title</h1>
+<a href="~/">Go to Homepage  </a>

--- a/CoreWiki/Startup.cs
+++ b/CoreWiki/Startup.cs
@@ -95,6 +95,8 @@ namespace CoreWiki
     var scope = app.ApplicationServices.CreateScope();
     var context = scope.ServiceProvider.GetService<ApplicationDbContext>();
 
+    app.UseStatusCodePagesWithReExecute("/HttpErrors/{0}");
+
     app.UseMvc();
     ApplicationDbContext.SeedData(context);
 


### PR DESCRIPTION
This PR aims to implement the wiki page not found issue https://github.com/csharpfritz/CoreWiki/issues/13

I've intentionally created two error pages. The first is for when the URL is a missing article slug (e.g `/a-non-existing-article`). This will show the 'Article not found' error page. The other 404 error page is is for more generic 404s (e.g `/some/url/that-does/not/exist`).

I would be grateful for any feedback, specifically:
- Any changes to the text in the 404 pages
- Is the `ArticleNotFound` ViewResult class a good approach? And should it be in the `CoreWiki.Helpers` namespace or elsewhere?

P.S @csharpfritz my apologies for my first two PRs (the tabs and editorconfig) today. I was apprehensive about committing a PR to the project and I thought a small code tidy (e.g the boy scout rule) could be a way to get started. I didn't mean to cause you frustration at the start of your week, rather I was trying to help but in hindsight I definitely didn't go the right way about it