### PR TITLE
Basic search functionality (Issue 3)

### DIFF
--- a/CoreWiki/Helpers/StringHelpers.cs
+++ b/CoreWiki/Helpers/StringHelpers.cs
@@ -1,0 +1,19 @@
+﻿namespace CoreWiki.Helpers
+{
+	public static class StringHelpers
+	{
+		/// <summary>
+		/// 	Returns the singular or plural noun based on the value of the count argument
+		/// </summary>
+		/// <param name="singular">E.g apple</param>
+		/// <param name="plural">E.g apples</param>
+		/// <param name="count">The total number of the item</param>
+		/// <param name="prependCount">true returns "4 apples", false returns just "apples"</param>
+		/// <returns></returns>
+		public static string Pluralize(string singular, string plural, int count, bool prependCount = false)
+		{
+			var noun = count == 1 ? singular : plural;
+			return prependCount ? $"{count} {noun}" : noun;
+		}
+	}
+}

--- a/CoreWiki/Helpers/StringHelpers.cs
+++ b/CoreWiki/Helpers/StringHelpers.cs
@@ -5,10 +5,10 @@
 		/// <summary>
 		/// 	Returns the singular or plural noun based on the value of the count argument
 		/// </summary>
-		/// <param name="singular">E.g apple</param>
-		/// <param name="plural">E.g apples</param>
-		/// <param name="count">The total number of the item</param>
-		/// <param name="prependCount">true returns "4 apples", false returns just "apples"</param>
+		/// <param name="singular">E.g person</param>
+		/// <param name="plural">E.g people</param>
+		/// <param name="count">The total number of items</param>
+		/// <param name="prependCount">true returns "4 people", false returns just "people"</param>
 		/// <returns></returns>
 		public static string Pluralize(string singular, string plural, int count, bool prependCount = false)
 		{

--- a/CoreWiki/Pages/All.cshtml
+++ b/CoreWiki/Pages/All.cshtml
@@ -1,8 +1,10 @@
 ﻿@page "{PageNumber?}"
-	@model CoreWiki.Pages.AllModel
-		@{
-			ViewData["Title"] = "All";
-		}
+@model CoreWiki.Pages.AllModel
+@using Microsoft.AspNetCore.Mvc.Rendering
+
+@{
+	ViewData["Title"] = "All";
+}
 
 		<h2>All Articles</h2>
 
@@ -26,25 +28,9 @@
 			}
 		</ul>*@
 
-		@foreach (var item in Model.Articles)
+		@foreach (var article in Model.Articles)
 		{
-
-			<div class="card border border-primary mb-3">
-				<div class="card-header">
-					<h3 class="card-title">
-						<a href="@($"/{(item.Slug == "home-page" ? "" : item.Slug)}")">@item.Topic</a>
-					</h3>
-				</div>
-				<div class="card-body">
-					<h6 class="card-subtitle mb-2 text-muted"><span data-value="@item.Published" class="timeStampValue"> @item.Published</span></h6>
-
-					<a class="card-link" asp-page="./Edit" asp-route-id="@item.Id">Edit</a>
-					<a class="card-link" asp-page="./Delete" asp-route-id="@item.Id">Delete</a>
-
-				</div>
-
-
-			</div>
+			@Html.Partial("_ArticleRow", article)
 		}
 
 		@section Styles {

--- a/CoreWiki/Pages/All.cshtml
+++ b/CoreWiki/Pages/All.cshtml
@@ -30,7 +30,7 @@
 
 		@foreach (var article in Model.Articles)
 		{
-			@Html.Partial("_ArticleRow", article)
+			@await Html.PartialAsync("_ArticleRow", article)
 		}
 
 		@section Styles {

--- a/CoreWiki/Pages/LatestChanges.cshtml
+++ b/CoreWiki/Pages/LatestChanges.cshtml
@@ -11,21 +11,6 @@
     <a asp-page="Create">New article</a>
 </p>
 
-@foreach (var item in Model.Article) {
-
-<div class="card border border-primary mb-3">
-	<div class="card-header">
-		<h3 class="card-title">
-            <a href="@($"/{(item.Slug == "home-page" ? "" : item.Slug)}")">@item.Topic</a>
-		</h3>
-	</div>
-	<div class="card-body">
-		<h6 class="card-subtitle mb-2 text-muted"><span data-value="@item.Published" class="timeStampValue"> @item.Published</span></h6>
-		<h6 class="card-subtitle mb-2 text-muted">View Count: <span> @item.ViewCount</span></h6>
-
-	<a class="card-link" asp-page="./Edit" asp-route-id="@item.Id">Edit</a>
-	<a class="card-link" asp-page="./Delete" asp-route-id="@item.Id">Delete</a>
-
-	</div>
-</div>
+@foreach (var article in Model.Article) {
+	@Html.Partial("_ArticleRow", article)
 }

--- a/CoreWiki/Pages/LatestChanges.cshtml
+++ b/CoreWiki/Pages/LatestChanges.cshtml
@@ -12,5 +12,5 @@
 </p>
 
 @foreach (var article in Model.Article) {
-	@Html.Partial("_ArticleRow", article)
+	@await Html.PartialAsync("_ArticleRow", article)
 }

--- a/CoreWiki/Pages/Search.cshtml
+++ b/CoreWiki/Pages/Search.cshtml
@@ -1,0 +1,33 @@
+@page
+@using Helpers
+@using Microsoft.AspNetCore.Mvc.Rendering
+@model SearchModel
+@{
+	ViewData["Title"] = "Search";
+	var searchResult = Model.SearchResult;
+}
+<h1 class="h1">Search CoreWiki</h1>
+<form action="/search" method="get" class="my-2">
+	<div class="form-group">
+		<div class="input-group">
+			<input class="form-control" type="text" name="q" value="@searchResult?.Query" placeholder="Search for articles on CoreWiki"/>
+			<div class="input-group-append">
+				<button class="btn badge-primary" type="submit">Search</button>
+			</div>
+		</div>
+	</div>
+</form>
+@if (searchResult != null)
+{
+	<div class="mb-2">
+		@StringHelpers.Pluralize("result", "results", @searchResult.TotalResults, prependCount: true)
+		found for <strong>@searchResult.Query</strong>
+	</div>
+
+	foreach(var article in searchResult.Articles)
+	{
+		@Html.Partial("_ArticleRow", article)
+	}
+}
+
+

--- a/CoreWiki/Pages/Search.cshtml
+++ b/CoreWiki/Pages/Search.cshtml
@@ -27,7 +27,7 @@
 @if (searchResult != null)
 {
 	<div class="mb-2">
-		@StringHelpers.Pluralize("result", "results", @searchResult.TotalResults, prependCount: true)
+		@StringHelpers.Pluralize("result", "results", searchResult.TotalResults, prependCount: true)
 		found for <strong>@searchResult.Query</strong>
 	</div>
 
@@ -38,8 +38,8 @@
 		total-pages="searchResult.TotalPages">
 	</pager>
 
-	foreach(var article in searchResult.Articles)
+	foreach(var article in searchResult.Results)
 	{
-		@Html.Partial("_ArticleRow", article)
+		@await Html.PartialAsync("_ArticleRow", article)
 	}
 }

--- a/CoreWiki/Pages/Search.cshtml
+++ b/CoreWiki/Pages/Search.cshtml
@@ -1,22 +1,29 @@
 @page
+@using System.Collections.Generic
 @using Helpers
 @using Microsoft.AspNetCore.Mvc.Rendering
 @model SearchModel
 @{
 	ViewData["Title"] = "Search";
 	var searchResult = Model.SearchResult;
+	var urlParams = new Dictionary<string, string>
+	{
+		{"Query", searchResult?.Query ?? ""}
+	};
 }
 <h1 class="h1">Search CoreWiki</h1>
+
 <form action="/search" method="get" class="my-2">
 	<div class="form-group">
 		<div class="input-group">
-			<input class="form-control" type="text" name="q" value="@searchResult?.Query" placeholder="Search for articles on CoreWiki"/>
+			<input class="form-control" type="text" name="Query" value="@searchResult?.Query" placeholder="Search for articles on CoreWiki"/>
 			<div class="input-group-append">
 				<button class="btn badge-primary" type="submit">Search</button>
 			</div>
 		</div>
 	</div>
 </form>
+
 @if (searchResult != null)
 {
 	<div class="mb-2">
@@ -24,10 +31,15 @@
 		found for <strong>@searchResult.Query</strong>
 	</div>
 
+	<pager
+		asp-page="Search"
+		url-params="urlParams"
+		current-page="searchResult.CurrentPage"
+		total-pages="searchResult.TotalPages">
+	</pager>
+
 	foreach(var article in searchResult.Articles)
 	{
 		@Html.Partial("_ArticleRow", article)
 	}
 }
-
-

--- a/CoreWiki/Pages/Search.cshtml.cs
+++ b/CoreWiki/Pages/Search.cshtml.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Linq;
+using CoreWiki.Models;
+using CoreWiki.SearchEngines;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace CoreWiki.Pages
+{
+	public class SearchModel : PageModel
+	{
+		public SearchResult SearchResult;
+		private readonly IArticlesSearchEngine _articlesSearchEngine;
+
+		public SearchModel(IArticlesSearchEngine articlesSearchEngine)
+		{
+			_articlesSearchEngine = articlesSearchEngine;
+		}
+
+		public IActionResult OnGet()
+		{
+			var isQueryPresent = Request.Query.TryGetValue("q", out var query);
+
+			if (isQueryPresent && !string.IsNullOrEmpty(query.First()))
+			{
+				SearchResult = _articlesSearchEngine.Search(query.First());
+			}
+
+			return Page();
+		}
+	}
+
+}

--- a/CoreWiki/Pages/Search.cshtml.cs
+++ b/CoreWiki/Pages/Search.cshtml.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Threading.Tasks;
+using CoreWiki.Models;
 using CoreWiki.SearchEngines;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -8,7 +9,7 @@ namespace CoreWiki.Pages
 {
 	public class SearchModel : PageModel
 	{
-		public SearchResult SearchResult;
+		public SearchResult<Article> SearchResult;
 		private readonly IArticlesSearchEngine _articlesSearchEngine;
 		private const int ResultsPerPage = 10;
 
@@ -17,7 +18,7 @@ namespace CoreWiki.Pages
 			_articlesSearchEngine = articlesSearchEngine;
 		}
 
-		public async Task<IActionResult> OnGet()
+		public async Task<IActionResult> OnGetAsync()
 		{
 			var isQueryPresent = TryGetSearchQuery(out var query);
 

--- a/CoreWiki/Pages/_ArticleRow.cshtml
+++ b/CoreWiki/Pages/_ArticleRow.cshtml
@@ -8,6 +8,7 @@
 	</div>
 	<div class="card-body">
 		<h6 class="card-subtitle mb-2 text-muted"><span data-value="@Model.Published" class="timeStampValue"> @Model.Published</span></h6>
+		<h6 class="card-subtitle mb-2 text-muted">View Count: <span> @Model.ViewCount</span></h6>
 
 		<a class="card-link" asp-page="./Edit" asp-route-id="@Model.Id">Edit</a>
 		<a class="card-link" asp-page="./Delete" asp-route-id="@Model.Id">Delete</a>

--- a/CoreWiki/Pages/_ArticleRow.cshtml
+++ b/CoreWiki/Pages/_ArticleRow.cshtml
@@ -1,0 +1,15 @@
+@model Models.Article
+
+<div class="card border border-primary mb-3">
+	<div class="card-header">
+		<h3 class="card-title">
+			<a href="@($"/{(Model.Slug == "home-page" ? "" : Model.Slug)}")">@Model.Topic</a>
+		</h3>
+	</div>
+	<div class="card-body">
+		<h6 class="card-subtitle mb-2 text-muted"><span data-value="@Model.Published" class="timeStampValue"> @Model.Published</span></h6>
+
+		<a class="card-link" asp-page="./Edit" asp-route-id="@Model.Id">Edit</a>
+		<a class="card-link" asp-page="./Delete" asp-route-id="@Model.Id">Delete</a>
+	</div>
+</div>

--- a/CoreWiki/Pages/_Layout.cshtml
+++ b/CoreWiki/Pages/_Layout.cshtml
@@ -20,16 +20,16 @@
 				<span class="navbar-toggler-icon"></span>
 			</button>
 			<div class="navbar-collapse collapse justify-content-between" id="navbarToggler">
-					<ul class="navbar-nav">
-						<li class="nav-item"><a class="nav-link" asp-page="./LatestChanges">Latest Changes</a></li>
-						<li class="nav-item"><a class="nav-link" asp-page="./All">All Articles</a></li>
-					</ul>
+				<ul class="navbar-nav">
+					<li class="nav-item"><a class="nav-link" asp-page="./LatestChanges">Latest Changes</a></li>
+					<li class="nav-item"><a class="nav-link" asp-page="./All">All Articles</a></li>
+					<li class="nav-item"><a class="nav-link" asp-page="./Search">Search</a></li>
+				</ul>
 
 				<ul class="navbar-nav">
 					<li class="nav-item"><a class="nav-link" href="~/Create">New Article</a></li>
 				</ul>
-
-				</div>
+			</div>
 		</nav>
 
 		<div class="container body-content">

--- a/CoreWiki/SearchEngines/ArticlesDbSearchEngine.cs
+++ b/CoreWiki/SearchEngines/ArticlesDbSearchEngine.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using CoreWiki.Models;
+
+namespace CoreWiki.SearchEngines
+{
+	public class ArticlesDbSearchEngine : IArticlesSearchEngine
+	{
+		private readonly ApplicationDbContext _context;
+
+		public ArticlesDbSearchEngine(ApplicationDbContext context)
+		{
+			_context = context;
+		}
+
+		public SearchResult Search(string query)
+		{
+			var filteredQuery = query.Trim();
+
+			var articles = _context.Articles.Where(article =>
+				article.Topic.ToUpper().Contains(filteredQuery.ToUpper()) ||
+				article.Content.ToUpper().Contains(filteredQuery.ToUpper())
+			).OrderBy(a => a.Topic).ToList();
+
+			return new SearchResult
+			{
+				Query = filteredQuery,
+				Articles = articles
+			};
+		}
+	}
+}

--- a/CoreWiki/SearchEngines/ArticlesDbSearchEngine.cs
+++ b/CoreWiki/SearchEngines/ArticlesDbSearchEngine.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices.ComTypes;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using CoreWiki.Models;
 using Microsoft.EntityFrameworkCore;
@@ -16,7 +14,7 @@ namespace CoreWiki.SearchEngines
 			_context = context;
 		}
 
-		public async Task<SearchResult> SearchAsync(string query, int pageNumber, int resultsPerPage)
+		public async Task<SearchResult<Article>> SearchAsync(string query, int pageNumber, int resultsPerPage)
 		{
 			var filteredQuery = query.Trim();
 			var offset = (pageNumber - 1) * resultsPerPage;
@@ -37,10 +35,10 @@ namespace CoreWiki.SearchEngines
 				.OrderByDescending(a => a.ViewCount)
 				.ToListAsync();
 
-			return new SearchResult
+			return new SearchResult<Article>
 			{
 				Query = filteredQuery,
-				Articles = articles,
+				Results = articles,
 				CurrentPage = pageNumber,
 				ResultsPerPage = resultsPerPage,
 				TotalResults = totalResults

--- a/CoreWiki/SearchEngines/IArticlesSearchEngine.cs
+++ b/CoreWiki/SearchEngines/IArticlesSearchEngine.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using CoreWiki.Models;
 
 namespace CoreWiki.SearchEngines
 {
 	public interface IArticlesSearchEngine
 	{
-		SearchResult Search(string query);
+		Task<SearchResult> SearchAsync(string query, int pageNumber, int resultsPerPage);
 	}
 }

--- a/CoreWiki/SearchEngines/IArticlesSearchEngine.cs
+++ b/CoreWiki/SearchEngines/IArticlesSearchEngine.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using CoreWiki.Models;
+
+namespace CoreWiki.SearchEngines
+{
+	public interface IArticlesSearchEngine
+	{
+		SearchResult Search(string query);
+	}
+}

--- a/CoreWiki/SearchEngines/IArticlesSearchEngine.cs
+++ b/CoreWiki/SearchEngines/IArticlesSearchEngine.cs
@@ -6,6 +6,6 @@ namespace CoreWiki.SearchEngines
 {
 	public interface IArticlesSearchEngine
 	{
-		Task<SearchResult> SearchAsync(string query, int pageNumber, int resultsPerPage);
+		Task<SearchResult<Article>> SearchAsync(string query, int pageNumber, int resultsPerPage);
 	}
 }

--- a/CoreWiki/SearchEngines/SearchResult.cs
+++ b/CoreWiki/SearchEngines/SearchResult.cs
@@ -4,11 +4,11 @@ using CoreWiki.Models;
 
 namespace CoreWiki.SearchEngines
 {
-	public class SearchResult
+	public class SearchResult<T>
 	{
 		public string Query { get; set; }
 
-		public List<Article> Articles { get; set; }
+		public List<T> Results { get; set; }
 
 		public int TotalResults { get; set; }
 

--- a/CoreWiki/SearchEngines/SearchResult.cs
+++ b/CoreWiki/SearchEngines/SearchResult.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using CoreWiki.Models;
+
+namespace CoreWiki.SearchEngines
+{
+	public class SearchResult
+	{
+		public string Query { get; set; }
+
+		public List<Article> Articles { get; set; }
+
+		public int TotalResults => Articles.Count;
+	}
+}

--- a/CoreWiki/SearchEngines/SearchResult.cs
+++ b/CoreWiki/SearchEngines/SearchResult.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using CoreWiki.Models;
 
 namespace CoreWiki.SearchEngines
@@ -9,6 +10,12 @@ namespace CoreWiki.SearchEngines
 
 		public List<Article> Articles { get; set; }
 
-		public int TotalResults => Articles.Count;
+		public int TotalResults { get; set; }
+
+		public int ResultsPerPage { get; set; }
+
+		public int CurrentPage { get; set; }
+
+		public int TotalPages => (int) Math.Ceiling((decimal)TotalResults / ResultsPerPage);
 	}
 }

--- a/CoreWiki/Startup.cs
+++ b/CoreWiki/Startup.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using CoreWiki.Models;
+using CoreWiki.SearchEngines;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
@@ -55,6 +56,8 @@ namespace CoreWiki
 
     // Add NodaTime clock for time-based testing
     services.AddSingleton<IClock>(SystemClock.Instance);
+
+	services.AddScoped<IArticlesSearchEngine, ArticlesDbSearchEngine>();
 
     services.AddRouting(options => options.LowercaseUrls = true);
 	  services.AddHttpContextAccessor();

--- a/CoreWiki/TagHelpers/PagerTagHelper.cs
+++ b/CoreWiki/TagHelpers/PagerTagHelper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Markdig.Helpers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -9,6 +10,7 @@ using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.Runtime.TagHelpers;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.EntityFrameworkCore;
 
 namespace CoreWiki.TagHelpers
 {
@@ -52,7 +54,6 @@ namespace CoreWiki.TagHelpers
 				}
 				else
 				{
-					object route = new { PageNumber = pageNum };
 					TagBuilder a;
 					a = _Generator.GeneratePageLink(
 						ViewContext,
@@ -62,7 +63,7 @@ namespace CoreWiki.TagHelpers
 						protocol: string.Empty,
 						hostname: string.Empty,
 						fragment: string.Empty,
-						routeValues: route,
+						routeValues: MakeRouteValues(pageNum),
 						htmlAttributes: null
 						);
 					a.AddCssClass("page-link");
@@ -79,6 +80,31 @@ namespace CoreWiki.TagHelpers
 
 		}
 
+		private Dictionary<string, string> MakeRouteValues(int pageNumber)
+		{
+			var route = new Dictionary<string, string>
+			{
+				{"PageNumber", pageNumber.ToString()}
+			};
+
+			if (UrlParams == null)
+			{
+				return route;
+			}
+
+			foreach (var key in UrlParams.Keys)
+			{
+				// We don't want to override existing values such as PageNumber
+				if (route.ContainsKey(key))
+				{
+					continue;
+				}
+				route.Add(key, UrlParams[key]);
+			}
+
+			return route;
+		}
+
 		/// <summary>
 		/// The name of the page.
 		/// </summary>
@@ -86,6 +112,11 @@ namespace CoreWiki.TagHelpers
 		/// Can be <c>null</c> if refering to the current page.
 		/// </remarks>
 		public string AspPage { get; set; }
+
+		/// <summary>
+		/// 	Optional. Enables adding url parameters (e.g '?query=test') to the link URL
+		/// </summary>
+		public Dictionary<string, string> UrlParams { get; set; }
 
 		/// <summary>
 		/// The number of the current page.

--- a/CoreWiki/TagHelpers/PagerTagHelper.cs
+++ b/CoreWiki/TagHelpers/PagerTagHelper.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Markdig.Helpers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -10,7 +9,6 @@ using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.Runtime.TagHelpers;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using Microsoft.EntityFrameworkCore;
 
 namespace CoreWiki.TagHelpers
 {


### PR DESCRIPTION
This PR aims to make a basic search engine for CoreWiki (Issue https://github.com/csharpfritz/CoreWiki/issues/3) that can be used as a foundation for more advanced search functionality later on.

My current search functionality is **VERY** basic. It simply does a case-insensitive search on the database to see if either the topic or content contains the query. Ordering is just by the Article view count DESC. I've implemented a `IArticlesSearchEngine` interface so it should be fairly easy to one day swap this basic search with something more advanced like ElasticSearch or Azure Search.

I also refactored the Article row from the All Articles page into a partial to keep the search page DRY. 

**Please note I've make a small UI tweak:** the Article row for 'All Articles' and the Article row for 'Latest Changes' were slightly different - the Latest Changes rows included a view count, whereas the All Articles rows did not. 

**TLDR:** 
- I've created basic search functionality that can be easily swapped out in the future via the `IArticlesSearchEngine` interface to something more advanced
- The All Articles page now shows the view count of each article, exactly like the Latest Changes page. If this is an issue let me know and I can change the Article Partial to show/hide the view count

### Items still on my todo list:
1. Pagination of the search results ✅ 
2. The links for each Article in article row don't work after the move to a partial for some reason ✅ 
    - This was due to slugs not being generated for Articles. E.g an unrelated bug that's now fixed on dev branch
3. Placing an inline search field in the nav bar. Bootstrap isn't playing nice and it just looked bad (see below). It looked even worse when the responsive layout kicked in. For now I've replaced it with simple link to the search page 
    - ❓ Maybe this UI improvement could be done in a future PR?

![search-nav-bar](https://user-images.githubusercontent.com/13892/40720706-f7f85b10-645a-11e8-96ed-8ab9b4736a88.png)
![search-responsive](https://user-images.githubusercontent.com/13892/40720708-f82eddde-645a-11e8-9af5-162753a0f30c.png)
