### PR TITLE
_ThemePartial to implement Light and Dark themes

### DIFF
--- a/CoreWiki/Pages/Shared/_ThemePartial.cshtml
+++ b/CoreWiki/Pages/Shared/_ThemePartial.cshtml
@@ -1,0 +1,32 @@
+﻿<select id="selectTheme" class="form-control form-control-sm text-muted">
+	<option class="bg-light text-primary">Light</option>
+	<option class="bg-dark text-white">Dark</option>
+</select>
+<script>
+	(function () {
+		'use strict';
+		function getCookie(name) {
+			var value = "; " + document.cookie;
+			var parts = value.split("; " + name + "=");
+			if (parts.length == 2) return parts.pop().split(";").shift();
+		}
+		if (getCookie("CoreWikiTheme") == "Dark") {
+			document.querySelector("#selectTheme").value = "Dark";
+			var themedItems = document.querySelectorAll("select, body, pre, .theme");
+			for (var t of themedItems) {
+				t.classList.add("bg-dark", "text-light");
+			}
+			var themedItems = document.querySelectorAll("a, button");
+			for (var t of themedItems) {
+				t.classList.add("text-light");
+			}
+		}
+		var select = document.getElementById("selectTheme");
+		select.addEventListener("change", function (ev) {
+			console.log("Select Theme: " + ev.target.value);
+			document.cookie = encodeURIComponent("CoreWikiTheme") + "=" + encodeURIComponent(ev.target.value) + "; path=/";;
+			location.reload();
+		});
+	})();
+</script>
+


### PR DESCRIPTION
This works by placing a cookie to represent the theme on the users machine. 

It uses cookies rather than identity because you may want different themes on different devices (like a phone)

Place ```<partial name="_ThemePartial" />``` wherever you want the selector