### PR TITLE
Fixed #93 and also fixed the styles for the _ThemePartial. Introduce Disqus as a comments option closing #67

### DIFF
--- a/CoreWiki/CoreWiki.csproj
+++ b/CoreWiki/CoreWiki.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <UserSecretsId>7b1e67c2-befb-4e2e-957d-603f8b2e5491</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.391" />

--- a/CoreWiki/Pages/Details.cshtml
+++ b/CoreWiki/Pages/Details.cshtml
@@ -35,8 +35,7 @@
 	}
 </div>
 
-@await Component.InvokeAsync("CreateComments", new Models.Comment { IdArticle = Model.Article.Id })
-@await Component.InvokeAsync("ListComments", @Model.Article.Comments)
+<partial name="_CommentsPartial" model="Model" />
 
 @section Scripts {
 	@await Html.PartialAsync("_EditorScript")

--- a/CoreWiki/Pages/Shared/_CommentsPartial.cshtml
+++ b/CoreWiki/Pages/Shared/_CommentsPartial.cshtml
@@ -1,0 +1,16 @@
+﻿@model DetailsModel
+@inject Microsoft.Extensions.Configuration.IConfiguration configuration
+@{
+	var settings = configuration.GetSection("Comments");
+	var isLocal = settings["Engine"] == "Local";
+	var shortname = settings["Disqus:ShortName"];
+}
+@if (isLocal)
+{
+	@await Component.InvokeAsync("CreateComments", new Models.Comment { IdArticle = Model.Article.Id })
+	@await Component.InvokeAsync("ListComments", @Model.Article.Comments)
+}
+else
+{
+	<partial name="_DisqusComments" model="shortname" />
+}

--- a/CoreWiki/Pages/Shared/_DisqusComments.cshtml
+++ b/CoreWiki/Pages/Shared/_DisqusComments.cshtml
@@ -1,0 +1,27 @@
+﻿@model string
+@{
+	var src = $"https://{Model}.disqus.com/embed.js";
+}
+<br />
+<h3>Disqus</h3>
+<hr />
+<div id="disqus_thread"></div>
+<script>
+
+/**
+*  RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
+*  LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables*/
+/*
+var disqus_config = function () {
+this.page.url = PAGE_URL;  // Replace PAGE_URL with your page's canonical URL variable
+this.page.identifier = PAGE_IDENTIFIER; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+};
+*/
+(function() { // DON'T EDIT BELOW THIS LINE
+var d = document, s = d.createElement('script');
+s.src = '@src';
+s.setAttribute('data-timestamp', +new Date());
+(d.head || d.body).appendChild(s);
+})();
+</script>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>

--- a/CoreWiki/Pages/Shared/_Layout.cshtml
+++ b/CoreWiki/Pages/Shared/_Layout.cshtml
@@ -18,11 +18,11 @@
 		<a href="~/" class="navbar-brand">CoreWiki</a>
 		<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarToggler" aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation">
 			<span class="navbar-toggler-icon"></span>
-		</button>		
+		</button>
 		<div class="navbar-collapse collapse justify-content-between" id="navbarToggler">
 			<ul class="navbar-nav">
-				<li class="nav-item"><a class="nav-link" asp-page="./LatestChanges">Latest Changes</a></li>
-				<li class="nav-item"><a class="nav-link" asp-page="./All">All Articles</a></li>
+				<li class="nav-item"><a class="nav-link" asp-page="/LatestChanges">Latest Changes</a></li>
+				<li class="nav-item"><a class="nav-link" asp-page="/All">All Articles</a></li>
 				<li>
 					<form class="form-inline mx-0 mx-lg-2 my-2 my-lg-0" action="/search" method="get">
 						<div class="input-group">
@@ -35,7 +35,7 @@
 				</li>
 			</ul>
 			<ul class="nav navbar-nav navbar-right">
-				<li class="nav-item"><a class="nav-link" href="~/Create">New Article</a></li>
+				<li class="nav-item"><a class="nav-link" asp-page="/Create">New Article</a></li>
 				<partial name="_LoginPartial" />
 			</ul>
 		</div>
@@ -47,10 +47,10 @@
 				@RenderBody()
 				<hr />
 				<footer>
-					<div class="row">
-							<div class-"col-8">&copy; @DateTime.UtcNow.Year - <a target="_blank" href="https://github.com/csharpfritz/CoreWiki">CoreWiki: An Open Source Project from the Fritz and Friends Community</a>
+					<div class="row justify-content-between">
+							<div class-"col-sm-12 col-md-8 ">&copy; @DateTime.UtcNow.Year - <a target="_blank" href="https://github.com/csharpfritz/CoreWiki">CoreWiki: An Open Source Project from the Fritz and Friends Community</a>
 							</div>
-						<div class="col-4 ml-auto"> 
+						<div class="col-sm-12 col-md-auto">
 							<partial name="_ThemePartial" />
 						</div>
 					</div>

--- a/CoreWiki/appsettings.json
+++ b/CoreWiki/appsettings.json
@@ -1,12 +1,18 @@
 {
-  "Url": "https://localhost:64908",
-  "Logging": {
-    "IncludeScopes": false,
-    "LogLevel": {
-      "Default": "Warning"
-    }
-  },
-  "ConnectionStrings": {
-    "CoreWikiIdentityContextConnection": "DataSource=./wikiIdentity.db"
-  }
+	"Url": "https://localhost:64908",
+	"Logging": {
+		"IncludeScopes": false,
+		"LogLevel": {
+			"Default": "Warning"
+		}
+	},
+	"ConnectionStrings": {
+		"CoreWikiIdentityContextConnection": "DataSource=./wikiIdentity.db"
+	},
+	"Comments": {
+		"Engine": "Local", // [Local | Disqus]
+		"Disqus": {
+			"ShortName": "" // Replace with shortname registered with Disqus
+		}
+	}	
 }


### PR DESCRIPTION
The fix for #93 was to remove the leading '.'

The 'Theme' select element will now respond to the size of the screen more accurately; When the screen is too small it will move to a new row and resize to fill the row.

I added an option for #67 Disqus as the comments engine for the Wiki.

To enable Disqus, complete the following checklist:

- [ ] Register a shortname for the site with Disqus
- [ ] Change the `Comments:Engine` from `Local` to `Disqus` in the `appsettings.json` file.
- [ ] Set the `Comments:Disqus:ShortName` value in the `appsettings.json` file to the shortname you registered with Disqus.