### PR TITLE
Updated estimated read time to use moment.js

### DIFF
--- a/CoreWiki/Helpers/StringHelpers.cs
+++ b/CoreWiki/Helpers/StringHelpers.cs
@@ -1,4 +1,7 @@
-﻿namespace CoreWiki.Helpers
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace CoreWiki.Helpers
 {
 	public static class StringHelpers
 	{
@@ -14,6 +17,31 @@
 		{
 			var noun = count == 1 ? singular : plural;
 			return prependCount ? $"{count} {noun}" : noun;
+		}
+		// <summary>
+		/// Returns the number of words in a string
+		/// </summary>
+		/// <param name="content">The string we wish to count the number of words contained within.</param>
+		/// <returns>The number of words in the sentance</returns>
+		public static int WordCount(this string content)
+		{
+			if (string.IsNullOrWhiteSpace(content))
+				return 0;
+
+			var matches = Regex.Matches(content, @"\b\S+\b");
+			return matches.Count;
+		}
+		/// <summary>
+		/// Returns the amount of time to read a string
+		/// </summary>
+		/// <param name="content">The string we wish to calculate.</param>
+		/// <returns>A TimeSpan of time required to read the string</returns>
+		public static TimeSpan CalculateReadTime(this string content)
+		{
+			const decimal wpm = 275.0m;
+			var wordCount = content.WordCount();
+			var minutes = (double)(wordCount / wpm);
+			return TimeSpan.FromMinutes(minutes);
 		}
 	}
 }

--- a/CoreWiki/Pages/Details.cshtml
+++ b/CoreWiki/Pages/Details.cshtml
@@ -9,21 +9,10 @@
 	ViewData["Title"] = title;
 }
 
-@functions  {
-
-	public int CalculateReadTime(string content)
-	{
-		const decimal wpm = 275.0m;
-		var wordCount = content.Split(' ').Length;
-		return (int)Math.Ceiling(wordCount / wpm);
-	}
-
-}
-
 <h2>@Model.Article.Topic</h2>
 <h5>Last Published: <span data-value="@Model.Article.Published" class="timeStampValue"> @Model.Article.Published</span></h5>
 <h5>View Count: <span data-value="@Model.Article.ViewCount"> @Model.Article.ViewCount</span></h5>
-<h5>Estimated Reading Time (minutes): <span> @CalculateReadTime(Model.Article.Content)</span></h5>
+<h5>Estimated Reading Time: <span class="duration" data-duration="@Model.Article.Content.CalculateReadTime().TotalMilliseconds"></span></h5>
 <markdown markdown="Article.Content" />
 
 <div>
@@ -40,18 +29,26 @@
 
 @section Scripts {
 	@await Html.PartialAsync("_EditorScript")
+	<script type="text/javascript">
+		$('.duration').each(function () {
+			var duration = Number($(this).attr('data-duration'));
+			$(this).text(moment.duration(duration).humanize());
+		});
+	</script>
 }
 
 @section Styles {
 	@await Html.PartialAsync("_EditorStyle")
 	<style>
-		.labelDisplayName {
+		.labelDisplayName
+		{
 			font-weight: bold;
 			text-transform: capitalize;
 			color: #007bb8 !important;
 		}
 
-		.labelCommentedOn {
+		.labelCommentedOn
+		{
 			color: #A6A6A6;
 			font-size: 10px;
 			height: 10px;

--- a/CoreWiki/Pages/_ViewImports.cshtml
+++ b/CoreWiki/Pages/_ViewImports.cshtml
@@ -1,4 +1,5 @@
 @using CoreWiki
+@using CoreWiki.Helpers
 @namespace CoreWiki.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, Westwind.AspNetCore.Markdown


### PR DESCRIPTION
I refactored the [CalculateReadTime](https://github.com/csharpfritz/CoreWiki/blob/aad16b0d78c8ea245896cd89c7c5dcdf61fbfa96/CoreWiki/Pages/Details.cshtml#L14) function to StringHelpers and instead of returning a calculated amount of minutes it returns a TimeSpan. I then use the milliseconds from the TimeSpan and moment.js' duration method to give a better representation of the total time it would take to read the article.

![corewikicap1](https://user-images.githubusercontent.com/8602418/40892927-50c4c0ea-6752-11e8-9628-0ddf938c8613.PNG)

![corewikicap2](https://user-images.githubusercontent.com/8602418/40892928-50dda5b0-6752-11e8-8c7b-1a8b28edeee5.PNG)