### PR TITLE
Added Seeder for IdentityDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -273,3 +273,4 @@ CoreWiki/wwwroot/lib/
 # Cake files
 [Tt]ools/
 [Oo]utput/
+*.pubxml

--- a/CoreWiki/Areas/Identity/Data/CoreWikiIdentityContext.cs
+++ b/CoreWiki/Areas/Identity/Data/CoreWikiIdentityContext.cs
@@ -23,5 +23,9 @@ namespace CoreWiki.Models
             // For example, you can rename the ASP.NET Identity table names and more.
             // Add your customizations after calling base.OnModelCreating(builder);
         }
-    }
+		internal static void SeedData(CoreWikiIdentityContext context)
+		{
+			context.Database.EnsureCreated();
+		}
+	}
 }

--- a/CoreWiki/Areas/Identity/IdentityHostingStartup.cs
+++ b/CoreWiki/Areas/Identity/IdentityHostingStartup.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using CoreWiki.Areas.Identity.Data;
 using CoreWiki.Models;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI;
@@ -11,18 +12,25 @@ using Microsoft.Extensions.DependencyInjection;
 [assembly: HostingStartup(typeof(CoreWiki.Areas.Identity.IdentityHostingStartup))]
 namespace CoreWiki.Areas.Identity
 {
-    public class IdentityHostingStartup : IHostingStartup
-    {
-        public void Configure(IWebHostBuilder builder)
-        {
-            builder.ConfigureServices((context, services) => {
-                services.AddDbContext<CoreWikiIdentityContext>(options =>
-                    options.UseSqlite(
-                        context.Configuration.GetConnectionString("CoreWikiIdentityContextConnection")));
+	public class IdentityHostingStartup : IHostingStartup
+	{
+		public void Configure(IWebHostBuilder builder)
+		{
+			builder.ConfigureServices((context, services) =>
+			{
+				services.AddDbContext<CoreWikiIdentityContext>(options =>
+					options.UseSqlite(
+						context.Configuration.GetConnectionString("CoreWikiIdentityContextConnection")));
 
-                services.AddDefaultIdentity<CoreWikiUser>()
-                    .AddEntityFrameworkStores<CoreWikiIdentityContext>();
-            });
-        }
-    }
+				services.AddDefaultIdentity<CoreWikiUser>()
+					.AddEntityFrameworkStores<CoreWikiIdentityContext>();
+
+				services.AddAuthentication().AddMicrosoftAccount(microsoftOptions =>
+				{
+					microsoftOptions.ClientId = context.Configuration["Authentication:Microsoft:ApplicationId"];
+					microsoftOptions.ClientSecret = context.Configuration["Authentication:Microsoft:Password"];
+				});
+			});
+		}
+	}
 }

--- a/CoreWiki/Startup.cs
+++ b/CoreWiki/Startup.cs
@@ -61,8 +61,8 @@ namespace CoreWiki
 					options.UseSqlite("Data Source=./wiki.db")
 				);
 
-    	// Add NodaTime clock for time-based testing
-    	services.AddSingleton<IClock>(SystemClock.Instance);
+			// Add NodaTime clock for time-based testing
+			services.AddSingleton<IClock>(SystemClock.Instance);
 
 			services.AddScoped<IArticlesSearchEngine, ArticlesDbSearchEngine>();
 
@@ -110,12 +110,13 @@ namespace CoreWiki
 
 			var scope = app.ApplicationServices.CreateScope();
 			var context = scope.ServiceProvider.GetService<ApplicationDbContext>();
+			var identityContext = scope.ServiceProvider.GetService<CoreWikiIdentityContext>();
 
-	    app.UseStatusCodePagesWithReExecute("/HttpErrors/{0}");
+			app.UseStatusCodePagesWithReExecute("/HttpErrors/{0}");
 
 			app.UseMvc();
 			ApplicationDbContext.SeedData(context);
-
+			CoreWikiIdentityContext.SeedData(identityContext);
 		}
 
 	}


### PR DESCRIPTION
On a fresh clone and run, the application requires IdentityMigrations ran on it, which could be an issue if the application is deployed somewhere. Instead of requiring a manual migration, we should seed the DB with the schema for Identity. Doing this will create a wikiIdentity.db file per the HostingStartup done per #86. I also added Microsoft social authentication, but whoever wants it will need to follow this

https://docs.microsoft.com/en-us/aspnet/core/security/authentication/social/microsoft-logins