### PR TITLE
build(vscode): workspace/launch settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,9 +267,6 @@ __pycache__/
 CoreWiki/wwwroot/lib/
 !CoreWiki/wwwroot/lib/simplemde
 
-# VSCode 
-.vscode/
-
 # Cake files
 [Tt]ools/
 [Oo]utput/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,46 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/CoreWiki/bin/Debug/netcoreapp2.1/CoreWiki.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/CoreWiki",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart",
+            "launchBrowser": {
+                "enabled": true,
+                "args": "${auto-detect-url}",
+                "windows": {
+                    "command": "cmd.exe",
+                    "args": "/C start ${auto-detect-url}"
+                },
+                "osx": {
+                    "command": "open"
+                },
+                "linux": {
+                    "command": "xdg-open"
+                }
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ,]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/CoreWiki/CoreWiki.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}


### PR DESCRIPTION
The .gitignore of the project was set to ignore the `.vscode` directory where vscode keeps its workspace settings.

While it is correct to ignore the `.vs` directory created by Visual Studio, the `.vscode` directory contains shared workspace configuration.

You can add a list of recommended extensions, formatting/tooling configuration you want everyone to share and, in the case of this PR, the pre-configured launch settings for debugging the ASP.NET Core app.

Including these settings in the repo could help a new dev on the project from accidentally mis-configuring their settings and having trouble debugging.