### PR TITLE
Replaced use of the word 'is' with 'are'

### DIFF
--- a/CoreWiki/Pages/Components/ListComments/ListComments.cshtml
+++ b/CoreWiki/Pages/Components/ListComments/ListComments.cshtml
@@ -7,7 +7,7 @@
     <div class="container">
         <div class="row">
             <div class="col-sm-auto">
-                <h6>There is no comments to show!</h6>
+                <h6>There are no comments to show!</h6>
             </div>
         </div>
     </div>


### PR DESCRIPTION
It is better to say "are" here, because the subject of the sentence "There are no  **comments** to show!" is plural.