### PR TITLE
Added Mads Kristensen's PWA nuget pkg

### DIFF
--- a/CoreWiki/CoreWiki.csproj
+++ b/CoreWiki/CoreWiki.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0" />
     <PackageReference Include="NodaTime" Version="2.3.0" />
     <PackageReference Include="Snickler.RSSCore" Version="1.0.2" />
+    <PackageReference Include="WebEssentials.AspNetCore.PWA" Version="1.0.33" />
     <PackageReference Include="Westwind.AspNetCore.Markdown" Version="3.0.28" />
   </ItemGroup>
 

--- a/CoreWiki/Pages/Shared/_Layout.cshtml
+++ b/CoreWiki/Pages/Shared/_Layout.cshtml
@@ -6,7 +6,6 @@
 <head>
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-	<link rel="manifest" href="/manifest.json">
 
 	<!-- Begin: Icon fallbacks for browsers where PWAs are not yet supported -->
 	<link rel="apple-touch-icon" sizes="57x57" href="/images/icons/icon-57x57.png">

--- a/CoreWiki/Startup.cs
+++ b/CoreWiki/Startup.cs
@@ -76,6 +76,8 @@ namespace CoreWiki
 					options.Conventions.AddPageRoute("/Details", @"Index");
 				});
 
+			services.AddProgressiveWebApp();
+
 		}
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
For #12 - Following on from the work to add a `manifest.json` file and wonderful icons, by @sgwatgit, I added Mads Kristensen's `WebEssentials.AspNetCore.PWA` nuget package to the project. Following this implementation, running the project in Chrome shows that we have a service worker running.

![image](https://user-images.githubusercontent.com/7979108/41189015-c346a40a-6bbf-11e8-860d-4b0495c03786.png)

See [this](https://github.com/madskristensen/WebEssentials.AspNetCore.ServiceWorker) page for details and further configuration options.
