### PR TITLE
Enhanced page routes to satisfy 'Change route definition (#27)'

### DIFF
--- a/CoreWiki/Pages/Delete.cshtml.cs
+++ b/CoreWiki/Pages/Delete.cshtml.cs
@@ -23,14 +23,14 @@ namespace CoreWiki.Pages
 
         ///  TODO: Make it so you cannot delete the home page (deleting the home page will cause a 404)
         ///  or re-factor to make the home page dynamic or configurable.
-        public async Task<IActionResult> OnGetAsync(int? id)
+        public async Task<IActionResult> OnGetAsync(string slug)
         {
-            if (id == null)
+            if (slug == null)
             {
                 return NotFound();
             }
 
-            Article = await _context.Articles.SingleOrDefaultAsync(m => m.Id == id);
+            Article = await _context.Articles.SingleOrDefaultAsync(m => m.Slug == slug);
 
             if (Article == null)
             {
@@ -39,14 +39,14 @@ namespace CoreWiki.Pages
             return Page();
         }
 
-        public async Task<IActionResult> OnPostAsync(int? id)
+        public async Task<IActionResult> OnPostAsync(string slug)
         {
-            if (id == null)
+            if (slug == null)
             {
                 return NotFound();
             }
 
-            Article = await _context.Articles.FindAsync(id);
+            Article = await _context.Articles.SingleOrDefaultAsync(m => m.Slug == slug);
 
             if (Article != null)
             {
@@ -54,7 +54,7 @@ namespace CoreWiki.Pages
                 await _context.SaveChangesAsync();
             }
 
-            return RedirectToPage("./Details");
+            return RedirectToPage("/All");
         }
     }
 }

--- a/CoreWiki/Pages/Edit.cshtml.cs
+++ b/CoreWiki/Pages/Edit.cshtml.cs
@@ -27,14 +27,14 @@ namespace CoreWiki.Pages
 		[BindProperty]
 		public Article Article { get; set; }
 
-		public async Task<IActionResult> OnGetAsync(int? id)
+		public async Task<IActionResult> OnGetAsync(string slug)
 		{
-			if (id == null)
+			if (slug == null)
 			{
 				return NotFound();
 			}
 
-			Article = await _context.Articles.SingleOrDefaultAsync(m => m.Id == id);
+			Article = await _context.Articles.SingleOrDefaultAsync(m => m.Slug == slug);
 
 			if (Article == null)
 			{

--- a/CoreWiki/Pages/_ArticleRow.cshtml
+++ b/CoreWiki/Pages/_ArticleRow.cshtml
@@ -14,8 +14,8 @@
 			<h6 class="card-subtitle mb-2 text-muted"><span data-value="@Model.Published" class="timeStampValue"> @Model.Published</span></h6>
 			<h6 class="card-subtitle mb-2 text-muted">View Count: <span> @Model.ViewCount</span></h6>
 
-			<a class="card-link btn btn-outline-info btn-sm" asp-page="./Edit" asp-route-id="@Model.Id">Edit</a>
-			<a class="card-link btn btn-outline-danger btn-sm" asp-page="./Delete" asp-route-id="@Model.Id">Delete</a>
+			<a class="card-link btn btn-outline-info btn-sm" asp-page="/Edit" asp-route-slug="@Model.Slug">Edit</a>
+			<a class="card-link btn btn-outline-danger btn-sm" asp-page="/Delete" asp-route-slug="@Model.Slug">Delete</a>
 		</div>
 	</div>
 

--- a/CoreWiki/Startup.cs
+++ b/CoreWiki/Startup.cs
@@ -63,6 +63,8 @@ namespace CoreWiki
 			services.AddMvc()
 				.AddRazorPagesOptions(options =>
 				{
+					options.Conventions.AddPageRoute("/Edit", "/{Slug}/Edit");
+					options.Conventions.AddPageRoute("/Delete", "{Slug}/Delete");
 					options.Conventions.AddPageRoute("/Details", "{Slug?}");
 					options.Conventions.AddPageRoute("/Details", @"Index");
 				});


### PR DESCRIPTION
The 'Edit' and 'Delete' routes will now work with /{Slug}/Edit and /{Slug}/Delete instead of /Edit?id={id} and /Delete?id={id}.