### PR TITLE
Added an Authorization tag helper

### DIFF
--- a/CoreWiki/Areas/Identity/AuthorizationPolicy.cs
+++ b/CoreWiki/Areas/Identity/AuthorizationPolicy.cs
@@ -14,7 +14,7 @@ namespace CoreWiki.Areas.Identity
 			options.AddPolicy("CanDeleteArticles", policy =>
 			{
 				policy.RequireAuthenticatedUser();
-				policy.RequireRole("Administrator");
+				policy.RequireRole("Administrators");
 			});
 
 			// Logged in users can write comments

--- a/CoreWiki/Pages/Delete.cshtml
+++ b/CoreWiki/Pages/Delete.cshtml
@@ -34,7 +34,7 @@
 
     <form method="post">
         <input type="hidden" asp-for="Article.Id" />
-        <input type="submit" value="Delete" class="btn btn-default" />
+        <input asp-policy="CanDeleteArticles" asp-policy-message="You do not have permission to delete this article." type="submit" value="Delete" class="btn btn-default" />
 
     </form>
     <div>

--- a/CoreWiki/Pages/_ArticleRow.cshtml
+++ b/CoreWiki/Pages/_ArticleRow.cshtml
@@ -18,16 +18,7 @@
 
 			<a class="card-link btn btn-outline-info btn-sm" asp-page="/Edit" asp-route-slug="@Model.Slug">Edit</a>
 
-			@if ((await AuthorizationService.AuthorizeAsync(User, "CanDeleteArticles")).Succeeded)
-			{
-
-				<a class="card-link btn btn-outline-danger btn-sm" asp-page="/Delete" asp-route-slug="@Model.Slug">Delete</a>
-
-			}
-			else
-			{
-				<span class="card-link btn btn-outline-danger disabled btn-sm" title="You do not have permission to delete this article">Delete</span>
-			}
+			<a class="card-link btn btn-outline-danger btn-sm" asp-policy="CanDeleteArticles" asp-policy-message="You do not have permission to delete this article." asp-page="/Delete" asp-route-slug="@Model.Slug">Delete</a>
 
 		</div>
 	</div>

--- a/CoreWiki/TagHelpers/AuthorizationTagHelper.cs
+++ b/CoreWiki/TagHelpers/AuthorizationTagHelper.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace CoreWiki.TagHelpers
+{
+	[HtmlTargetElement("a", Attributes = "asp-policy")]
+	[HtmlTargetElement("a", Attributes = "asp-policy, asp-policy-hidden")]
+	[HtmlTargetElement("a", Attributes = "asp-policy, asp-policy-message")]
+	[HtmlTargetElement("button", Attributes = "asp-policy")]
+	[HtmlTargetElement("button", Attributes = "asp-policy, asp-policy-hidden")]
+	[HtmlTargetElement("button", Attributes = "asp-policy, asp-policy-message")]
+	[HtmlTargetElement("input", Attributes = "asp-policy")]
+	[HtmlTargetElement("input", Attributes = "asp-policy, asp-policy-hidden")]
+	[HtmlTargetElement("input", Attributes = "asp-policy, asp-policy-message")]
+	public class AuthorizationTagHelper : TagHelper, IAuthorizeData
+    {
+		private readonly HttpContext _httpContext;
+		private readonly IAuthorizationService _authorizationService;
+		private readonly IAuthorizationPolicyProvider _policyProvider;
+
+		public AuthorizationTagHelper(IHttpContextAccessor httpContextAccessor, IAuthorizationService authorizationService, IAuthorizationPolicyProvider policyProvider)
+		{
+			this._httpContext = httpContextAccessor.HttpContext;
+			this._authorizationService = authorizationService;
+			this._policyProvider = policyProvider;
+		}
+
+		/// <summary>
+		/// Gets or sets the policies that determines access to the HTML element.
+		/// </summary>
+		[HtmlAttributeName("asp-policy")]		
+		public string Policy { get; set; }
+
+		/// <summary>
+		/// Gets or sets whether the HTML block is hidden or not when the user doesn't have permission.
+		/// </summary>
+		[HtmlAttributeName("asp-policy-hidden")]
+		public bool SuppressOutput { get; set; }
+
+		/// <summary>
+		/// Gets or sets the message placed on the HTML block when the user doesn't have permission.
+		/// </summary>
+		[HtmlAttributeName("asp-policy-message")]
+		public string Message { get; set; }
+
+		public string Roles { get; set; }
+
+		public string AuthenticationSchemes { get; set; }
+
+		public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+		{
+			var message = Message ?? "You do not have permission to complete this action.";
+			var policy = await AuthorizationPolicy.CombineAsync(_policyProvider, new[] { this });
+			var authorizationResult = await _authorizationService.AuthorizeAsync(_httpContext.User, policy);
+			if (!authorizationResult.Succeeded)
+			{
+				if (SuppressOutput)
+				{
+					// Hide the HTML element
+					output.SuppressOutput();
+					return;
+				}
+
+				// Add a title attribute to the HTML element explaining the reason why the element is disabled
+				output.Attributes.Add("title", message);
+
+				// Determine if a class attribute is present; if the class attribute exists then append it else add it
+				if (output.Attributes.TryGetAttribute("class", out var classAttribute))
+				{
+					// Append the "disabled" class to the list of classes
+					output.Attributes.SetAttribute("class", $"{classAttribute.Value} disabled");
+				}
+				else
+				{
+					// Add the "disabled" class to the HTML element
+					output.Attributes.Add("class", "disabled");
+				}
+
+				switch (context.TagName)
+				{
+					// If the HTML element is a link, convert the element to a span and remove the href attribute
+					case "a":
+						output.Attributes.Remove(output.Attributes["href"]);
+						output.TagName = "span";
+						break;
+					// If the HTML element is an input or submit element, disable it
+					case "button":
+					case "input":
+						output.Attributes.Add("disabled", "");
+						break;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This new tag helper will allow you to use two of three new attributes on an HTML element. These attributes will either hide or add a `title` attribute with a customized message. By default the `title` attribute will tell the user that they do not have permission to complete the action.

The `asp-policy` attribute will tell the tag helper which policies the user must have.
The `asp-policy-message` attribute will create the `title` attribute on the HTML element.
The `asp-policy-hidden` attribute will hide the HTML element if the user doesn't have the policies required.