### PR TITLE
Make buttons uniform across the site.

### DIFF
--- a/CoreWiki/Pages/Components/CreateComments/CreateComments.cshtml
+++ b/CoreWiki/Pages/Components/CreateComments/CreateComments.cshtml
@@ -33,7 +33,7 @@
 		</div>
 		<div class="row">
 			<div class="form-group">
-				<input type="submit" value="Submit" class="btn btn-default" />
+				<button type="submit" class="btn btn-outline-primary">Submit</button>
 			</div>
 		</div>
 	</div>

--- a/CoreWiki/Pages/Create.cshtml
+++ b/CoreWiki/Pages/Create.cshtml
@@ -25,16 +25,17 @@
 					</div>
 					<div class="form-group">
 						<div class="input-group mb-3">
-							<input type="submit" value="Create" class="btn btn-default" />
-  						<div class="input-group-prepend">
-    						<span class="input-group-text">Upload</span>
-  						</div>
+							<div class="input-group-prepend">
+								<span class="input-group-text">Upload</span>
+							</div>
 							<div class="custom-file">
 								<input type="file" class="custom-file-input" id="inputGroupFile01" onchange="openFile(event)">
 								<label class="custom-file-label" for="inputGroupFile01">Choose file</label>
 							</div>
 						</div>
-
+					</div>
+					<div class="form-group">
+						<button type="submit" class="btn btn-outline-primary">Create</button>
 					</div>
 				</form>
 			</div>

--- a/CoreWiki/Pages/CreateArticleFromLink.cshtml
+++ b/CoreWiki/Pages/CreateArticleFromLink.cshtml
@@ -29,9 +29,9 @@
 			<div class="form-group">
 				<input type="hidden" asp-for="Article.Slug" />
 				<div class="input-group mb-3">
-					<input type="submit" value="Yes" class="btn btn-default" asp-page-handler="CreateLinks" asp-route-slug=@Model.Article.Slug />
+					<button type="submit" class="btn btn-outline-primary" asp-page-handler="CreateLinks" asp-route-slug=@Model.Article.Slug>Yes</button>
 					<span>&nbsp;</span>
-					<input type="submit" value="No" class="btn btn-default" asp-page-handler="Cancel" asp-route-slug=@Model.Article.Slug />
+					<button type="submit" class="btn btn-outline-primary" asp-page-handler="Cancel" asp-route-slug=@Model.Article.Slug>No</button>
 				</div>
 			</div>
 		</form>

--- a/CoreWiki/Pages/Delete.cshtml
+++ b/CoreWiki/Pages/Delete.cshtml
@@ -34,7 +34,7 @@
 
     <form method="post">
         <input type="hidden" asp-for="Article.Id" />
-        <input type="submit" value="Delete" class="btn btn-default" />
+        <button type="submit" class="btn btn-outline-primary">Delete</button>
 
     </form>
     <div>

--- a/CoreWiki/Pages/Edit.cshtml
+++ b/CoreWiki/Pages/Edit.cshtml
@@ -26,7 +26,6 @@
 			</div>
 			<div class="form-group">
 				<div class="input-group mb-3">
-				<input type="submit" value="Save" class="btn btn-default" />
 					<div class="input-group-prepend">
 						<span class="input-group-text">Upload</span>
 					</div>
@@ -35,6 +34,9 @@
 						<label class="custom-file-label" for="inputGroupFile01">Choose file</label>
 					</div>
 				</div>
+			</div>
+			<div class="form-group">
+				<button type="submit" class="btn btn-outline-primary">Save</button>
 			</div>
 		</form>
 	</div>


### PR DESCRIPTION
- The buttons on the Add & Edit pages blended into the upload control.
- Bootstrap doesn't have a "btn-default" class, swap for "btn-outline-primary" which is used elsewhere in the site.