### PR TITLE
Change ports for dev server

### DIFF
--- a/CoreWiki/Properties/launchSettings.json
+++ b/CoreWiki/Properties/launchSettings.json
@@ -21,7 +21,7 @@
 			"environmentVariables": {
 				"ASPNETCORE_ENVIRONMENT": "Development"
 			},
-			"applicationUrl": "https://localhost:5001;http://localhost:5000"
+			"applicationUrl": "https://localhost:8081;http://localhost:8080"
 		}
 	}
 }


### PR DESCRIPTION
On OSX, `dotnet run` can fail with "port in use". Port 5000 is used by
Apple Time Capsule, Port 5001 used by some VPN software (e.g. Cisco
AnyConnect)