### PR TITLE
Allow creation of Article from 404 page.

### DIFF
--- a/CoreWiki.Test/Helpers/UrlHelperTests.cs
+++ b/CoreWiki.Test/Helpers/UrlHelperTests.cs
@@ -1,0 +1,22 @@
+using System;
+using CoreWiki.Helpers;
+using Xunit;
+
+namespace CoreWiki.Test
+{
+    public class UrlHelperTests
+    {
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("one-two", "One Two")]
+        [InlineData("onetwo", "Onetwo")]
+        [InlineData("one-two-three", "One Two Three")]
+        [InlineData("él-sofá", "Él Sofá")]
+        public void SlugShouldBeATopic(string slug, string expected_topic)
+        {
+            string actual_topic = UrlHelpers.SlugToTopic(slug);
+            Assert.Equal(expected_topic, actual_topic);
+        }
+    }
+}

--- a/CoreWiki/Helpers/UrlHelpers.cs
+++ b/CoreWiki/Helpers/UrlHelpers.cs
@@ -9,6 +9,16 @@ namespace CoreWiki.Helpers
 
 		private static readonly Regex reSlugCharacters = new Regex(@"([\s,.//\\-_=])+");
 
+		public static string SlugToTopic(string slug)
+		{
+			if (string.IsNullOrEmpty(slug))
+			{
+				return "";
+			}
+
+			return slug.ToTitleCase().RemoveHyphens();
+		}
+
 		public static string URLFriendly(string title)
 		{
 

--- a/CoreWiki/Pages/ArticleNotFound.cshtml
+++ b/CoreWiki/Pages/ArticleNotFound.cshtml
@@ -3,5 +3,11 @@
 	ViewData["Title"] = title;
 }
 <h1>@title</h1>
-<p>Please check that the URL you entered is correct. It's also possible that an article at this address was deleted.</p>
+
+<ul>
+	<li>Please check that the URL you entered is correct.</li>
+	<li>It's also possible that an article at this address was deleted.</li>
+	<li>Would you like to <a asp-page="/Create">create</a> the page?</li>
+</ul>
+
 <a href="~/">Go to Homepage</a>

--- a/CoreWiki/Pages/Create.cshtml.cs
+++ b/CoreWiki/Pages/Create.cshtml.cs
@@ -9,6 +9,7 @@ using NodaTime;
 using CoreWiki.Models;
 using CoreWiki.Helpers;
 using Microsoft.Extensions.Logging;
+using Microsoft.EntityFrameworkCore;
 
 namespace CoreWiki.Pages
 {
@@ -26,7 +27,27 @@ namespace CoreWiki.Pages
             this.Logger = loggerFactory.CreateLogger("CreatePage");
         }
 
-        public IActionResult OnGet() => Page();
+        public async Task<IActionResult> OnGetAsync(string slug)
+        {
+            if (string.IsNullOrEmpty(slug))
+            {
+                return Page();
+            }
+
+            Article article = await _context.Articles.SingleOrDefaultAsync(m => m.Slug == slug);
+
+            if (article != null)
+            {
+                return Redirect($"/{slug}/Edit");
+            }
+
+            Article = new Article()
+            {
+                Topic = UrlHelpers.SlugToTopic(slug)
+            };
+
+            return Page();
+        }
 
         [BindProperty]
         public Article Article { get; set; }

--- a/CoreWiki/Pages/Details.cshtml.cs
+++ b/CoreWiki/Pages/Details.cshtml.cs
@@ -23,6 +23,9 @@ namespace CoreWiki.Pages
 
 		public Article Article { get; set; }
 
+		[ViewDataAttribute]
+		public string Slug { get; set; }
+
 		public async Task<IActionResult> OnGetAsync(string slug)
 		{
 
@@ -34,6 +37,7 @@ namespace CoreWiki.Pages
 
 			if (Article == null)
 			{
+				Slug = slug;
 				return new ArticleNotFoundResult(slug);
 			}
 

--- a/CoreWiki/Pages/Shared/_Layout.cshtml
+++ b/CoreWiki/Pages/Shared/_Layout.cshtml
@@ -70,7 +70,7 @@
 				</li>
 			</ul>
 			<ul class="nav navbar-nav navbar-right">
-				<li class="nav-item"><a class="nav-link" asp-page="/Create">New Article</a></li>
+				<li class="nav-item"><a class="nav-link" href="/Create">New Article</a></li>
 				<partial name="_LoginPartial" />
 			</ul>
 		</div>

--- a/CoreWiki/Startup.cs
+++ b/CoreWiki/Startup.cs
@@ -72,6 +72,7 @@ namespace CoreWiki
 					options.Conventions.AddPageRoute("/Delete", "{Slug}/Delete");
 					options.Conventions.AddPageRoute("/Details", "{Slug?}");
 					options.Conventions.AddPageRoute("/Details", @"Index");
+					options.Conventions.AddPageRoute("/Create", "{Slug?}/Create");
 				});
 
 			services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();


### PR DESCRIPTION
404 page contains a create link.  Create get() modified to check if
the slug exists or not.  If it does, redirect to the Edit page.  If
it does not, show the Create page with the Topic pre-filled with an
attempt to "de-slugify" it.

Closes #135, #122