### PR TITLE
Add ability to change a Topic

### DIFF
--- a/CoreWiki/Migrations/20180624223112_AddSlugHistory.Designer.cs
+++ b/CoreWiki/Migrations/20180624223112_AddSlugHistory.Designer.cs
@@ -3,14 +3,16 @@ using System;
 using CoreWiki.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace CoreWiki.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180624223112_AddSlugHistory")]
+    partial class AddSlugHistory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/CoreWiki/Migrations/20180624223112_AddSlugHistory.cs
+++ b/CoreWiki/Migrations/20180624223112_AddSlugHistory.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace CoreWiki.Migrations
+{
+    public partial class AddSlugHistory : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SlugHistories",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    ArticleId = table.Column<int>(nullable: true),
+                    OldSlug = table.Column<string>(nullable: true),
+                    Added = table.Column<DateTime>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SlugHistories", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SlugHistories_Articles_ArticleId",
+                        column: x => x.ArticleId,
+                        principalTable: "Articles",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SlugHistories_ArticleId",
+                table: "SlugHistories",
+                column: "ArticleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SlugHistories_OldSlug_Added",
+                table: "SlugHistories",
+                columns: new[] { "OldSlug", "Added" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SlugHistories");
+        }
+    }
+}

--- a/CoreWiki/Models/ApplicationDbContext.cs
+++ b/CoreWiki/Models/ApplicationDbContext.cs
@@ -18,10 +18,13 @@ namespace CoreWiki.Models
 
 			modelBuilder.Entity<Article>().HasIndex(a => a.Slug).IsUnique();
 
+			modelBuilder.Entity<SlugHistory>().HasIndex(a => new { a.OldSlug, a.AddedDateTime });
+
 		}
 
 		public DbSet<Article> Articles { get; set; }
 		public DbSet<Comment> Comments { get; set; }
+		public DbSet<SlugHistory> SlugHistories { get; set; }
 
 	internal static void SeedData(ApplicationDbContext context)
 		{

--- a/CoreWiki/Models/SlugHistory.cs
+++ b/CoreWiki/Models/SlugHistory.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
+using NodaTime;
+using NodaTime.Extensions;
+
+namespace CoreWiki.Models
+{
+	public class SlugHistory
+	{
+		[Required, Key]
+		[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+		public int Id { get; set; }
+
+		public virtual Article Article { get; set; }
+
+		public string OldSlug { get; set; }
+
+		[NotMapped]
+		public Instant Added { get; set; }
+
+		[Obsolete("This property only exists for EF serialization purposes")]
+		[DataType(DataType.DateTime)]
+		[Column("Added")]
+        [EditorBrowsable(EditorBrowsableState.Never)] // Make it harder to shoot are selfs in the foot.
+		public DateTime AddedDateTime
+		{
+			get => Added.ToDateTimeUtc();
+			set => Added = DateTime.SpecifyKind(value, DateTimeKind.Utc).ToInstant();
+		}
+    }
+}

--- a/CoreWiki/Pages/Details.cshtml.cs
+++ b/CoreWiki/Pages/Details.cshtml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -34,7 +34,18 @@ namespace CoreWiki.Pages
 
 			if (Article == null)
 			{
-				return new ArticleNotFoundResult(slug);
+				var historical = await _context.SlugHistories.Include(h => h.Article)
+					.OrderByDescending(h => h.Added)
+					.FirstOrDefaultAsync(h => h.OldSlug == slug.ToLowerInvariant());
+
+				if (historical != null)
+				{
+					return new RedirectResult($"~/{historical.Article.Slug}");
+				}
+				else
+				{
+					return new ArticleNotFoundResult(slug);
+				}
 			}
 
 			if (Request.Cookies[Article.Topic] == null)

--- a/CoreWiki/Pages/Edit.cshtml
+++ b/CoreWiki/Pages/Edit.cshtml
@@ -12,11 +12,10 @@
 	<div class="col-md-12">
 		<form method="post">
 			<input type="hidden" asp-for="Article.Id" />
-			<input type="hidden" asp-for="Article.Topic" />
 			<div asp-validation-summary="ModelOnly" class="text-danger"></div>
 			<div class="form-group">
 				<label asp-for="Article.Topic" class="control-label"></label>
-				<span>@Model.Article.Topic</span>
+				<input asp-for="Article.Topic" class="form-control" />
 				<span asp-validation-for="Article.Topic" class="text-danger"></span>
 			</div>
 			<div class="form-group">


### PR DESCRIPTION
We don't want existing links to be broken so if the Topic of an Article
is changed, which means the Slug has changed, record the old Slug so
we can look it up and do a 302 if an Article request would normally 404.

Closes #121 though does it in a different way.  I wasn't a fan of an article having a permanent slug so `<site>/no` could land on a page where the Topic is "yes".  Doing it this way, if the Slug changes from `no` to `yes` then `<site>/no` 302s to `<site>/yes` where the Topic is "yes".  Somebody can then come along and create a proper `<site>/no` page.

The one unhandled situation is SlugHistory table could grow large over time and should be trimmed periodically if another Article has taken over the Slug.