### PR TITLE
fix home page edit bug #145

### DIFF
--- a/CoreWiki/Models/ApplicationDbContext.cs
+++ b/CoreWiki/Models/ApplicationDbContext.cs
@@ -33,13 +33,13 @@ namespace CoreWiki.Models
 
 
 			// Load an initial home page
-			if (!context.Articles.Any(a => a.Topic == "HomePage"))
+			if (!context.Articles.Any(a => a.Topic == "Home Page"))
 			{
 
 				var homePageArticle = new Article
 				{
 
-					Topic = "HomePage",
+					Topic = "Home Page",
 					Slug= "home-page",
 					Content = "This is the default home page.  Please change me!",
 					Published = SystemClock.Instance.GetCurrentInstant()


### PR DESCRIPTION
Was seeding database with "HomePage" instead of "Home Page" - which changed slug when an edit page was saved to the database.

Closes #145