### PR TITLE
Expended on email notification feature and added email templates, closes #149

### DIFF
--- a/CoreWiki/Configuration/AppSettings.cs
+++ b/CoreWiki/Configuration/AppSettings.cs
@@ -11,7 +11,7 @@ namespace CoreWiki.Configuration
 		public Uri Url { get; set; }
 		public Connectionstrings ConnectionStrings { get; set; }
 		public Comments Comments { get; set; }
-
+		public EmailNotifications EmailNotifications { get; set; }
 	}
 
 	public class Connectionstrings
@@ -36,5 +36,12 @@ namespace CoreWiki.Configuration
 	{
 		public string ShortName { get; set; }
 
+	}
+
+	public class EmailNotifications
+	{
+		public string SendGridApiKey { get; set; }
+		public string FromEmailAddress { get; set; }
+		public string FromName { get; set; }
 	}
 }

--- a/CoreWiki/EmailTemplates/NewComment.tmpl
+++ b/CoreWiki/EmailTemplates/NewComment.tmpl
@@ -1,0 +1,12 @@
+﻿﻿﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <title>{{Title}}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+</head>
+<body style="margin: 0; padding: 0;">
+{{CommentDisplayName}} left a comment on your article {{ArticleTitle}}
+Click on the following link to view the comment: {{ArticleUrl}}
+</body>
+</html>

--- a/CoreWiki/Services/EmailMessageFormatter.cs
+++ b/CoreWiki/Services/EmailMessageFormatter.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+
+namespace CoreWiki.Services
+{
+	public class EmailMessageFormatter : IEmailMessageFormatter
+	{
+		private readonly ITemplateProvider _templateProvider;
+		private readonly ITemplateParser _templateParser;
+
+		public EmailMessageFormatter(ITemplateProvider templateProvider, ITemplateParser templateParser)
+		{
+			_templateProvider = templateProvider;
+			_templateParser = templateParser;
+		}
+		public async Task<string> FormatEmailMessage<T>(string templateName, T model) where T : class
+		{
+			var template = await _templateProvider.GetTemplateContent(templateName);
+
+			return _templateParser.Format<T>(template, model);
+		}
+	}
+}

--- a/CoreWiki/Services/EmailNotifier.cs
+++ b/CoreWiki/Services/EmailNotifier.cs
@@ -1,46 +1,67 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using CoreWiki.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using SendGrid;
 using SendGrid.Helpers.Mail;
-using Microsoft.Extensions.Configuration;
-using Microsoft.AspNetCore.Identity.UI.Services;
+using System;
+using System.Net;
+using System.Threading.Tasks;
 
 namespace CoreWiki.Services
 {
-	public class EmailNotifier : IEmailSender
+	public class EmailNotifier : IEmailNotifier
 	{
-		private IConfiguration _configuration;
+		private readonly EmailNotifications _configuration;
+		private readonly ILogger _logger;
 
-		public EmailNotifier(IConfiguration configuration)
+		public EmailNotifier(IConfiguration configuration, ILoggerFactory loggerFactory)
 		{
-			_configuration = configuration;
+			_configuration = configuration.GetSection(nameof(EmailNotifications)).Get<EmailNotifications>();
+			_logger = loggerFactory.CreateLogger<EmailNotifier>();
 		}
 
-		public async Task SendEmailAsync(string recipientEmail, string subject, string body) {
-
-			// Don't do anything if SendGrid isn't configured
-			if (string.IsNullOrEmpty(_configuration["SendGridApiKey"])) return;
-
-			var msg = new SendGridMessage();
-
-			msg.SetFrom(new EmailAddress("noreply@corewiki.jeffreyfritz.com", "No Reply Team"));
-
-			var recipient = new EmailAddress(recipientEmail);
-
-			msg.AddTo(recipient);
-			msg.SetSubject(subject);
-
-			// TODO: Permalink to comment
-			msg.AddContent(MimeType.Html, body);
-
-			var apiKey = _configuration["SendGridApiKey"];
-			var client = new SendGridClient(apiKey);
-
-			var response = await client.SendEmailAsync(msg);
-
+		public async Task<bool> SendEmailAsync(string recipientEmail, string subject, string body)
+		{
+			return await SendEmailAsync(recipientEmail, string.Empty, subject, body);
 		}
 
+		public async Task<bool> SendEmailAsync(string recipientEmail, string recipientName, string subject, string body)
+		{
+			if (string.IsNullOrWhiteSpace(_configuration.SendGridApiKey))
+			{
+				_logger.LogInformation($"Missing SendGridApiKey setting in {nameof(EmailNotifications)}");
+
+				return false;
+			}
+
+			if (string.IsNullOrWhiteSpace(_configuration.FromEmailAddress))
+			{
+				_logger.LogInformation($"Missing from FromEmailAddress setting in {nameof(EmailNotifications)}");
+
+				return false;
+			}
+
+			if (string.IsNullOrWhiteSpace(recipientEmail))
+			{
+				throw new ArgumentException(nameof(recipientEmail));
+			}
+
+			var message = new SendGridMessage();
+			var from = new EmailAddress(_configuration.FromEmailAddress, _configuration.FromName);
+			var to = new EmailAddress(recipientEmail, recipientName);
+
+			message.SetFrom(from);
+			message.AddTo(to);
+			message.SetSubject(subject);
+			message.AddContent(MimeType.Html, body);
+
+			var client = new SendGridClient(_configuration.SendGridApiKey);
+
+			var response = await client.SendEmailAsync(message);
+
+			_logger.LogInformation($"Sent email form {from.Email} to {to.Email} response {response.StatusCode}");
+
+			return response.StatusCode == HttpStatusCode.OK;
+		}
 	}
 }

--- a/CoreWiki/Services/IEmailMessageFormatter.cs
+++ b/CoreWiki/Services/IEmailMessageFormatter.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace CoreWiki.Services
+{
+	public interface IEmailMessageFormatter
+    {
+		Task<string> FormatEmailMessage<T>(string templateName, T model) where T : class;
+    }
+}

--- a/CoreWiki/Services/IEmailNotifier.cs
+++ b/CoreWiki/Services/IEmailNotifier.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+
+namespace CoreWiki.Services
+{
+	public interface IEmailNotifier
+    {
+		Task<bool> SendEmailAsync(string recipientEmail, string subject, string body);
+		Task<bool> SendEmailAsync(string recipientEmail, string recipientName, string subject, string body);
+
+	}
+}

--- a/CoreWiki/Services/INotificationService.cs
+++ b/CoreWiki/Services/INotificationService.cs
@@ -1,0 +1,11 @@
+﻿using CoreWiki.Areas.Identity.Data;
+using CoreWiki.Models;
+using System.Threading.Tasks;
+
+namespace CoreWiki.Services
+{
+	public interface INotificationService
+    {
+		Task<bool> NotifyAuthorNewComment(CoreWikiUser author, Article article, Comment comment);
+	}
+}

--- a/CoreWiki/Services/ITemplateParser.cs
+++ b/CoreWiki/Services/ITemplateParser.cs
@@ -1,0 +1,7 @@
+﻿namespace CoreWiki.Services
+{
+	public interface ITemplateParser
+    {
+		string Format<T>(string template, T model) where T : class;
+    }
+}

--- a/CoreWiki/Services/ITemplateProvider.cs
+++ b/CoreWiki/Services/ITemplateProvider.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace CoreWiki.Services
+{
+	public interface ITemplateProvider
+    {
+		Task<string> GetTemplateContent(string templateName);
+    }
+}

--- a/CoreWiki/Services/NotificationService.cs
+++ b/CoreWiki/Services/NotificationService.cs
@@ -1,0 +1,52 @@
+﻿using CoreWiki.Areas.Identity.Data;
+using CoreWiki.Configuration;
+using CoreWiki.Models;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
+using System.Threading.Tasks;
+
+namespace CoreWiki.Services
+{
+	public class NotificationService : INotificationService
+	{
+		private readonly IEmailMessageFormatter _emailMessageFormatter;
+		private readonly IEmailNotifier _emailNotifier;
+		private readonly UserManager<CoreWikiUser> _userManager;
+		private readonly AppSettings _appSettings;
+
+		public NotificationService(
+			IEmailMessageFormatter emailMessageFormatter,
+			IEmailNotifier emailNotifier,
+			UserManager<CoreWikiUser> userManager,
+			IConfiguration configuration)
+		{
+			_emailMessageFormatter = emailMessageFormatter;
+			_emailNotifier = emailNotifier;
+			_userManager = userManager;
+			_appSettings = configuration.Get<AppSettings>();
+		}
+
+		public async Task<bool> NotifyAuthorNewComment(CoreWikiUser author, Article article, Comment comment)
+		{
+			if (!author.CanNotify) return false;
+			if (string.IsNullOrWhiteSpace(author.Email)) return false;
+
+			var model = new
+			{
+				AuthorName = author.UserName,
+				Title = "CoreWiki Notification", 
+				CommentDisplayName = comment.DisplayName,
+				ArticleTitle = article.Topic,
+				ArticleUrl = GetUrlForArticle(article)
+			};
+			var messageBody = await _emailMessageFormatter.FormatEmailMessage("NewComment", model);
+
+			return await _emailNotifier.SendEmailAsync(author.Email, "Someone said something about your article", messageBody);
+		}
+
+		private string GetUrlForArticle(Article article)
+		{
+			return $"{_appSettings.Url}{article.Topic}";
+		}
+	}
+}

--- a/CoreWiki/Services/TemplateParser.cs
+++ b/CoreWiki/Services/TemplateParser.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+
+namespace CoreWiki.Services
+{
+	public class TemplateParser : ITemplateParser
+	{
+		public TemplateParser()
+		{
+		}
+
+		public string Format<T>(string template, T model) where T : class
+		{
+			var propertyValueDict = GetPropertyValueDictionary<T>(model);
+
+			foreach (var propertyValue in propertyValueDict)
+			{
+				var placeholder = $"{{{{{propertyValue.Key}}}}}";
+				template = template.Replace(placeholder, propertyValue.Value.ToString());
+			}
+
+			return template;
+		}
+
+		private IDictionary<string, object> GetPropertyValueDictionary<T>(T model) where T: class
+		{
+			var result = new Dictionary<string, object>();
+
+			foreach (var property in model.GetType().GetProperties())
+			{
+				result.Add(property.Name, property.GetValue(model, null));
+			}
+
+			return result;
+		}
+	}
+}

--- a/CoreWiki/Services/TemplateProvider.cs
+++ b/CoreWiki/Services/TemplateProvider.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace CoreWiki.Services
+{
+	public class TemplateProvider : ITemplateProvider
+    {
+		public const string DEFAULT_TEMPLATE_EXTENSION = "tmpl";
+		private readonly string _templateRootFolder;
+
+		public TemplateProvider(IHostingEnvironment hostingEnvironment)
+		{
+			_templateRootFolder = Path.Combine(hostingEnvironment.ContentRootPath, "EmailTemplates"); ;
+		}
+
+		public async Task<string> GetTemplateContent(string templateName)
+		{
+			var fullPath = GetFullPath(_templateRootFolder, $"{templateName}.{DEFAULT_TEMPLATE_EXTENSION}");
+
+			if (!File.Exists(fullPath))
+			{
+				throw new Exception($"Template {templateName} was not found in {_templateRootFolder}");
+			}
+
+			return await File.ReadAllTextAsync(fullPath);
+		}
+
+		private string GetFullPath(string path, string filename)
+		{
+			return Path.Combine(path, filename);
+		}
+	}
+}

--- a/CoreWiki/Startup.cs
+++ b/CoreWiki/Startup.cs
@@ -26,12 +26,13 @@ using Microsoft.ApplicationInsights.Extensibility;
 using CoreWiki.Areas.Identity.Data;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
+using CoreWiki.Services;
 
 namespace CoreWiki
 {
 	public class Startup
 	{
-		public Startup(IConfiguration configuration)
+		public Startup(IConfiguration configuration, IHostingEnvironment hostingEnvironment)
 		{
 			Configuration = configuration;
 		}
@@ -62,6 +63,11 @@ namespace CoreWiki
 			services.AddSingleton<IClock>(SystemClock.Instance);
 
 			services.AddScoped<IArticlesSearchEngine, ArticlesDbSearchEngine>();
+			services.AddScoped<ITemplateProvider ,TemplateProvider>();
+			services.AddScoped<ITemplateParser, TemplateParser>();
+			services.AddScoped<IEmailMessageFormatter, EmailMessageFormatter>();
+			services.AddScoped<IEmailNotifier, EmailNotifier>();
+			services.AddScoped<INotificationService, NotificationService>();
 
 			services.AddRouting(options => options.LowercaseUrls = true);
 			services.AddHttpContextAccessor();
@@ -76,7 +82,6 @@ namespace CoreWiki
 				});
 
 			services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
-			services.AddSingleton<IEmailSender, Services.EmailNotifier>();
 
 			services.AddProgressiveWebApp();
 

--- a/CoreWiki/appsettings.json
+++ b/CoreWiki/appsettings.json
@@ -22,5 +22,9 @@
 			"ShortName": "" // Replace with shortname registered with Disqus
 		}
 	},
-	"SendGridApiKey":  ""
+	"EmailNotifications": {
+		"SendGridApiKey": "",
+		"FromEmailAddress": "noreply@corewiki.jeffreyfritz.com",
+		"FromName": "No Reply Team"
+	}
 }


### PR DESCRIPTION
Issue #149

Adding a basic email templating service and email sender to send notification emails, expending on the work already done by Jeff and Amanda. 
In this pull request only 'new comment' notifications are sent but can easily be extended to send email verification emails.
The email template is very basic and could do with a little love and attention.

### New Settings
```json
{
"EmailNotifications": {
    "SendGridApiKey": "",
    "FromEmailAddress": "noreply@corewiki.jeffreyfritz.com",
    "FromName": "No Reply Team"
}
```

### New Services
Added multiple new services:

* ```ITemplateProvider```: Reads template files from disk (EmailTemplates directory).
* ```ITemplateParser```: Replaces template placeholders with data from a model.
* ```IEmailMessageFormatter```: Uses ```ITemplateProvider``` and ```ITemplateParser``` to create a email message.
* ```INotificationService```: Currently only uses ```IEmailNotifier``` to send emails but can be used in the future to send other kinds of notifications as suggested in #112.

### New Folders
The EmailTemplates folder is where the TemplateProvider looks for templates based on a given name and optional extension. The default template extension is '.tmpl'.

### TemplateParser
The template parser looks in a template for placeholders. Placeholders are formatted with double curly braces '{{Placeholder}}'. It looks on the model for a property with the same name as the placeholder and replaces the placeholder with the property value.

Template:
```
Template {{Placeholder1}} and {{Placeholder2}}
```
Model:
```csharp
var model = new
    {
        Placeholder1= value1,
        Placeholder2 = value2
    };
```
Result:
```
Template value1 and value2
```

### NotificationService

The ```INotificationService``` currently only implements a single method. In this setup the ```INotificationService``` is where new notification methods should be implemented. The service can select by which method a notification should be sent i.e. email, text, whatsapp.
```csharp
public interface INotificationService
{
    Task<bool> NotifyAuthorNewComment(CoreWikiUser author, Article article, Comment comment);
}
```