### PR TITLE
Enable unit testing for model validation

### DIFF
--- a/CoreWiki.Test/CoreWiki.Test.csproj
+++ b/CoreWiki.Test/CoreWiki.Test.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Moq" Version="4.8.3" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/CoreWiki.Test/Validation/ArticleValidatorTests.cs
+++ b/CoreWiki.Test/Validation/ArticleValidatorTests.cs
@@ -1,0 +1,51 @@
+﻿using Xunit;
+using FluentValidation.TestHelper;
+using CoreWiki.Validation;
+using Microsoft.Extensions.Localization;
+using Moq;
+
+namespace CoreWiki.Test.Validation
+{
+    public class ArticleValidatorTests
+    {
+        private ArticleValidator _validator;
+
+        public ArticleValidatorTests()
+        {
+            var mock = new Mock<IStringLocalizer<ArticleValidator>>();
+            mock.Setup(_ => _["ArticleTopicIsRequired"]).Returns(new LocalizedString("ArticleTopicIsRequired", "ArticleTopicIsRequired"));
+            mock.Setup(_ => _["ArticleTopicExceedsMaximumLength"]).Returns(new LocalizedString("ArticleTopicExceedsMaximumLength", "ArticleTopicExceedsMaximumLength"));
+            _validator = new ArticleValidator(mock.Object);
+        }
+
+        [Fact]
+        public void ArticleTopic_ShouldThrowValidationError_WhenEmpty()
+        {
+            _validator.ShouldHaveValidationErrorFor(article => article.Topic, "");
+        }
+
+        [Fact]
+        public void ArticleTopic_ShouldThrowValidationError_WhenWhitespace()
+        {
+            _validator.ShouldHaveValidationErrorFor(article => article.Topic, new string(' ', 10));
+        }
+
+        [Fact]
+        public void ArticleTopic_ShouldThrowValidationError_WhenNull()
+        {
+            _validator.ShouldHaveValidationErrorFor(article => article.Topic, null as string);
+        }
+
+        [Fact]
+        public void ArticleTopic_ShouldThrowValidationError_WhenLongerThanMaximumLength()
+        {
+            _validator.ShouldHaveValidationErrorFor(article => article.Topic, new string('a', 101));
+        }
+
+        [Fact]
+        public void ArticleTopic_ShouldNotThrowValidationError_WhenWithinMaximumLength()
+        {
+            _validator.ShouldNotHaveValidationErrorFor(article => article.Topic, new string('a', 100));
+        }
+    }
+}

--- a/CoreWiki/CoreWiki.csproj
+++ b/CoreWiki/CoreWiki.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.391" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="7.6.103" />
     <PackageReference Include="HtmlSanitizer" Version="4.0.185" />
     <PackageReference Include="Humanizer" Version="2.3.3" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.3.0" />

--- a/CoreWiki/Globalization/Validation/ArticleValidator.resx
+++ b/CoreWiki/Globalization/Validation/ArticleValidator.resx
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="ArticleTopicExceedsMaximumLength" xml:space="preserve">
+    <value>Please enter a shorter topic (maximum: 100 characters)</value>
+  </data>
+  <data name="ArticleTopicIsRequired" xml:space="preserve">
+    <value>Please enter a topic</value>
+  </data>
+</root>

--- a/CoreWiki/Models/Article.cs
+++ b/CoreWiki/Models/Article.cs
@@ -17,7 +17,6 @@ namespace CoreWiki.Models
 		[DatabaseGenerated(DatabaseGeneratedOption.Identity)]
 		public int Id { get; set; }
 
-		[Required, MaxLength(100)]
 		[Display(Name = "Topic")]
 		public string Topic { get; set; }
 

--- a/CoreWiki/Pages/Create.cshtml.cs
+++ b/CoreWiki/Pages/Create.cshtml.cs
@@ -56,15 +56,14 @@ namespace CoreWiki.Pages
 
         public async Task<IActionResult> OnPostAsync()
         {
-
-            var slug = UrlHelpers.URLFriendly(Article.Topic.ToLower());
-            Article.Slug = slug;
-						Article.AuthorId = Guid.Parse(this.User.FindFirstValue(ClaimTypes.NameIdentifier));
-
             if (!ModelState.IsValid)
             {
                 return Page();
             }
+
+            var slug = UrlHelpers.URLFriendly(Article.Topic.ToLower());
+            Article.Slug = slug;
+            Article.AuthorId = Guid.Parse(this.User.FindFirstValue(ClaimTypes.NameIdentifier));
 
             //check if the slug already exists in the database.
             Logger.LogWarning($"Creating page with slug: {slug}");

--- a/CoreWiki/Startup.cs
+++ b/CoreWiki/Startup.cs
@@ -28,6 +28,9 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using CoreWiki.Services;
 using Microsoft.AspNetCore.Localization;
+using FluentValidation.AspNetCore;
+using FluentValidation;
+using CoreWiki.Validation;
 
 namespace CoreWiki
 {
@@ -85,7 +88,10 @@ namespace CoreWiki
 					options.Conventions.AddPageRoute("/Details", "{Slug?}");
 					options.Conventions.AddPageRoute("/Details", @"Index");
 					options.Conventions.AddPageRoute("/Create", "{Slug?}/Create");
-				});
+				})
+				.AddFluentValidation();
+
+			services.AddTransient<IValidator<Article>, ArticleValidator>();
 
 			services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 

--- a/CoreWiki/Validation/ArticleValidator.cs
+++ b/CoreWiki/Validation/ArticleValidator.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using CoreWiki.Models;
+using FluentValidation;
+using Microsoft.Extensions.Localization;
+
+namespace CoreWiki.Validation
+{
+	public class ArticleValidator : AbstractValidator<Article>
+	{
+		public ArticleValidator(IStringLocalizer<ArticleValidator> localizer)
+		{
+			RuleFor(o => o.Topic)
+				.NotEmpty().WithMessage(localizer["ArticleTopicIsRequired"])
+				.MaximumLength(100).WithMessage(localizer["ArticleTopicExceedsMaximumLength"]);
+		}
+	}
+}


### PR DESCRIPTION
Extends the use of data annotation at current, but can completely replace them.

* Leaves the models nice and clean
* Separation of concerns
* Easier to unit test validators