### PR TITLE
Remove `App_Data` from .gitignore so new users can run the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
-App_Data/
 
 # Visual Studio 2015 cache/options directory
 .vs/


### PR DESCRIPTION
I recently re-cloned the project and attempted to start it up; unfortunately I ran into the error described in https://github.com/csharpfritz/CoreWiki/issues/181. The SQL Lite EF Provider is unable to create the `App_Data` directory, which does not exist in the project upon a fresh clone. You would run into the issue when `context.Database.Migrate();` was called.

Removing this from the `.gitignore` and manually creating the `App_Data` folder fixes this issue and allows new users to get up and running!

Taking advice from @parithon I've verified that `.db` files are ignored.

p.s. this is `programmingwithdan` from Twitch