### PR TITLE
Fix missing `<script>` tag

### DIFF
--- a/CoreWiki/Pages/All.cshtml
+++ b/CoreWiki/Pages/All.cshtml
@@ -42,7 +42,7 @@
 </style>
 }
 
-
+<script>
     function UpdatePageSize(value) {
         document.cookie = encodeURIComponent("PageSize") + "=" + encodeURIComponent(value) + "; path=/";
         location = '/all/1';


### PR DESCRIPTION
A regression was introduced in commit [c371aca](https://github.com/csharpfritz/CoreWiki/commit/c371acae0a200980bf3351a6078f45353ea4208e). The `All.cshtml` page needs an opening `<script>` tag 👍 