### PR TITLE
Updated to latest nuget packages

### DIFF
--- a/CoreWiki.Test/CoreWiki.Test.csproj
+++ b/CoreWiki.Test/CoreWiki.Test.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/CoreWiki/CoreWiki.csproj
+++ b/CoreWiki/CoreWiki.csproj
@@ -7,7 +7,7 @@
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.391" />
     <PackageReference Include="DiffPlex" Version="1.4.1" />
     <PackageReference Include="HtmlSanitizer" Version="4.0.185" />
-    <PackageReference Include="Humanizer" Version="2.3.3" />
+    <PackageReference Include="Humanizer" Version="2.4.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.1" />
@@ -17,7 +17,7 @@
     <PackageReference Include="NWebsec.AspNetCore.Mvc.TagHelpers" Version="2.0.0" />
     <PackageReference Include="sendgrid" Version="9.9.0" />
     <PackageReference Include="Snickler.RSSCore" Version="1.0.3" />
-    <PackageReference Include="WebEssentials.AspNetCore.PWA" Version="1.0.33" />
+    <PackageReference Include="WebEssentials.AspNetCore.PWA" Version="1.0.42" />
     <PackageReference Include="Westwind.AspNetCore.Markdown" Version="3.0.28" />
   </ItemGroup>
 


### PR DESCRIPTION
I updated to the latest nuget packages and checked with the `dotnet outdated` global tool to know whether we have all latest versions everywhere in the project.

the global tool dotnet-outdated can be found at [https://github.com/jerriep/dotnet-outdated](https://github.com/jerriep/dotnet-outdated) and works in a similar way as `npm outdated`.