### PR TITLE
Pagerfix

### DIFF
--- a/CoreWiki/TagHelpers/PagerTagHelper.cs
+++ b/CoreWiki/TagHelpers/PagerTagHelper.cs
@@ -42,6 +42,8 @@ namespace CoreWiki.TagHelpers
 			ul.AddCssClass("pagination");
 			output.MergeAttributes(ul);
 
+			if (CurrentPage < 1) CurrentPage = 1;
+
 			AppendPreNavigationButtons(output);
 			AppendNavigationButtons(output);
 			AppendPostNavigationButtons(output);


### PR DESCRIPTION
An issue came up on stream when working on the search page, where the pager would have clickable next / last navigation buttons, even though there was only one page.

This was due to the fact that the PagerTagHelper uses CurrentPage to decide whether to show these. The default value on the property for the TagHelper is set to 1, but it seems when getting search results, this value was defaulting to 0.