### PR TITLE
Made UserAdmin only available to administrators

### DIFF
--- a/CoreWiki.Data/Security/SeedDefaultAdminUser.cs
+++ b/CoreWiki.Data/Security/SeedDefaultAdminUser.cs
@@ -1,0 +1,53 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
+
+namespace CoreWiki.Data.Security
+{
+	//Todo - This is a bit of a hack to ensure that there is a default admin user on first run, can probably remove when the first start wizard is implemented
+	public static class SeedDefaultAdminUserToAdminRole
+	{
+		public static async Task Seed(UserManager<CoreWikiUser> userManager, RoleManager<IdentityRole> roleManager)
+		{
+			var administratorsRole = "Administrators";
+			var defaultAdminUsername = "admin@corewiki.com";
+			var defaultAdminPassword = "Admin@123";
+
+			var adminRoleExists = await roleManager.RoleExistsAsync(administratorsRole);
+
+			if (!adminRoleExists)
+			{
+				var role = new IdentityRole(administratorsRole)
+				{
+					Name = administratorsRole
+				};
+
+				var roleResult = await roleManager.CreateAsync(role);
+			}
+
+			// If there are no users who are currently an admin, then create a default admin user
+			var anyAdminUsers = await userManager.GetUsersInRoleAsync(administratorsRole);
+
+			if (!anyAdminUsers.Any())
+			{
+				var defaultAdminUserExists = await userManager.FindByEmailAsync(defaultAdminUsername);
+
+				if (defaultAdminUserExists == null)
+				{
+					var defaultAdminUser = new CoreWikiUser
+					{
+						UserName = defaultAdminUsername,
+						Email = defaultAdminUsername
+					};
+
+					var userResult = await userManager.CreateAsync(defaultAdminUser, defaultAdminPassword);
+
+					if (userResult.Succeeded)
+					{
+						var result = await userManager.AddToRoleAsync(defaultAdminUser, administratorsRole);
+					}
+				}
+			}
+		}
+	}
+}

--- a/CoreWiki/Areas/Identity/AuthorizationPolicy.cs
+++ b/CoreWiki/Areas/Identity/AuthorizationPolicy.cs
@@ -6,42 +6,43 @@ namespace CoreWiki.Areas.Identity
 {
 	public class AuthPolicy
 	{
+		/// <summary>
+		/// Requires the user to be logged in and have the Administrator role
+		/// </summary>
+		/// <value>
+		/// The require administrator role.
+		/// </value>
+		public static AuthorizationPolicy RequireAdministratorRole => new AuthorizationPolicyBuilder().RequireAuthenticatedUser().RequireRole("Administrators").Build();
+
+
+		/// <summary>
+		/// Requires the user to be logged in.
+		/// </summary>
+		/// <value>
+		/// The require logged in user.
+		/// </value>
+		public static AuthorizationPolicy RequireLoggedInUser => new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build();
+
+		/// <summary>
+		/// Requires the user to be logged in and be in one or more of the required roles specified.
+		/// </summary>
+		/// <param name="roles">The roles.</param>
+		/// <returns></returns>
+		public static AuthorizationPolicy RequireUserWithEitherRole(string[] roles) => new AuthorizationPolicyBuilder().RequireAuthenticatedUser().RequireAnyRole(roles).Build();
 
 		internal static void Execute(AuthorizationOptions options)
 		{
-
-			options.AddPolicy(PolicyConstants.CanDeleteArticles, policy =>
-			{
-				policy.RequireAuthenticatedUser();
-				policy.RequireRole("Administrators");
-			});
-
-			options.AddPolicy(PolicyConstants.CanCreateComments, policy =>
-			{
-				policy.RequireAuthenticatedUser();
-			});
-
-			options.AddPolicy(PolicyConstants.CanWriteArticles, policy =>
-			{
-				policy.RequireAuthenticatedUser();
-				// TODO: Re-enable when we can assign users to a role
-				// policy.RequireAnyRole("Authors", "Administrators");
-			});
-
-			options.AddPolicy(PolicyConstants.CanEditArticles, policy =>
-			{
-				policy.RequireAuthenticatedUser();
-
-				// TODO: After we can assign users to roles, we will want to re-enable this
-
-				// policy.RequireAnyRole("Authors", "Administrators");
-			});
+			options.AddPolicy(PolicyConstants.CanDeleteArticles, RequireAdministratorRole);
+			options.AddPolicy(PolicyConstants.CanManageRoles, RequireAdministratorRole);
+			options.AddPolicy(PolicyConstants.CanDeleteArticles, RequireAdministratorRole);
+			options.AddPolicy(PolicyConstants.CanManageRoles, RequireAdministratorRole);
+			options.AddPolicy(PolicyConstants.CanCreateComments, RequireLoggedInUser);
+			options.AddPolicy(PolicyConstants.CanWriteArticles, RequireUserWithEitherRole(new[] { "Authors", "Administrators" }));
+			options.AddPolicy(PolicyConstants.CanEditArticles, RequireUserWithEitherRole(new[] {"Authors", "Administrators"}));
 
 			// Authors can edit their own articles
 			// Editors can edit anyones articles
 
 		}
 	}
-
-
 }

--- a/CoreWiki/Areas/Identity/IdentityHostingStartup.cs
+++ b/CoreWiki/Areas/Identity/IdentityHostingStartup.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using CoreWiki.Data.Security;
-using Microsoft.AspNetCore.Builder;
+﻿using CoreWiki.Data.Security;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Identity.UI;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,42 +18,38 @@ namespace CoreWiki.Areas.Identity
 					out var requireConfirmedEmail);
 
 				services.AddDbContext<CoreWikiIdentityContext>(options =>
-																	options.UseSqlite(
-																					context.Configuration.GetConnectionString("CoreWikiIdentityContextConnection")));
+					options.UseSqlite(
+						context.Configuration.GetConnectionString("CoreWikiIdentityContextConnection")));
 
-				services.AddDefaultIdentity<CoreWikiUser>(options =>
+				services.AddIdentity<CoreWikiUser, IdentityRole>(options =>
 						options.SignIn.RequireConfirmedEmail = requireConfirmedEmail)
 					.AddRoles<IdentityRole>()
 					.AddRoleManager<RoleManager<IdentityRole>>()
+					.AddDefaultUI()
+					.AddDefaultTokenProviders()
 					.AddEntityFrameworkStores<CoreWikiIdentityContext>();
 
 				var authBuilder = services.AddAuthentication();
 
 				if (!string.IsNullOrEmpty(context.Configuration["Authentication:Microsoft:ApplicationId"]))
 				{
-
 					authBuilder.AddMicrosoftAccount(microsoftOptions =>
 					{
 						microsoftOptions.ClientId = context.Configuration["Authentication:Microsoft:ApplicationId"];
 						microsoftOptions.ClientSecret = context.Configuration["Authentication:Microsoft:Password"];
 					});
-
 				}
 
 				if (!string.IsNullOrEmpty(context.Configuration["Authentication:Twitter:ConsumerKey"]))
 				{
-
 					authBuilder.AddTwitter(twitterOptions =>
 					{
 						twitterOptions.ConsumerKey = context.Configuration["Authentication:Twitter:ConsumerKey"];
 						twitterOptions.ConsumerSecret = context.Configuration["Authentication:Twitter:ConsumerSecret"];
 					});
-
 				}
 
 				services.AddAuthorization(AuthPolicy.Execute);
-
-
 			});
 		}
 	}

--- a/CoreWiki/Areas/Identity/PolicyConstants.cs
+++ b/CoreWiki/Areas/Identity/PolicyConstants.cs
@@ -2,11 +2,10 @@
 {
 	public static class PolicyConstants
 	{
-
 		public const string CanDeleteArticles = nameof(CanDeleteArticles);
 		public const string CanCreateComments = nameof(CanCreateComments);
 		public const string CanWriteArticles = nameof(CanWriteArticles);
 		public const string CanEditArticles = nameof(CanEditArticles);
+		public const string CanManageRoles = nameof(CanManageRoles);
 	}
-
 }

--- a/CoreWiki/Configuration/Startup/ConfigureRouting.cs
+++ b/CoreWiki/Configuration/Startup/ConfigureRouting.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using CoreWiki.Areas.Identity;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -26,6 +27,7 @@ namespace CoreWiki.Configuration.Startup
 					options.Conventions.AddPageRoute("/Search", "/LatestChanges");
 					options.Conventions.AddPageRoute("/Create", "{Slug?}/Create");
 					options.Conventions.AddPageRoute("/History", "{Slug?}/History");
+					options.Conventions.AuthorizeAreaFolder("Identity", "/UserAdmin", PolicyConstants.CanManageRoles);
 				});
 
 			return services;

--- a/CoreWiki/Configuration/Startup/ConfigureSecurityAndAuthentication.cs
+++ b/CoreWiki/Configuration/Startup/ConfigureSecurityAndAuthentication.cs
@@ -1,5 +1,8 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System.Threading.Tasks;
+using CoreWiki.Data.Security;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CoreWiki.Configuration.Startup
@@ -28,10 +31,11 @@ namespace CoreWiki.Configuration.Startup
 			return app;
 		}
 
-		public static IApplicationBuilder ConfigureAuthentication(this IApplicationBuilder app)
+		public static async Task<IApplicationBuilder> ConfigureAuthentication(this IApplicationBuilder app, UserManager<CoreWikiUser> userManager, RoleManager<IdentityRole> roleManager)
 		{
 			app.UseCookiePolicy();
 			app.UseAuthentication();
+			await SeedDefaultAdminUserToAdminRole.Seed(userManager, roleManager);
 			return app;
 		}
 	}

--- a/CoreWiki/Pages/Shared/_Layout.cshtml
+++ b/CoreWiki/Pages/Shared/_Layout.cshtml
@@ -1,8 +1,12 @@
 ﻿@using System.IO
+@using System.Security.Claims
 @using CoreWiki.Areas.Identity
+@using Data.Security
+@using Microsoft.AspNetCore.Identity
 
 @inject Microsoft.AspNetCore.Hosting.IHostingEnvironment env
 @inject Microsoft.AspNetCore.Http.IHttpContextAccessor context
+@inject UserManager<CoreWikiUser> UserManager
 @inject IOptionsSnapshot<AppSettings> settings
 
 <!DOCTYPE html>
@@ -59,9 +63,15 @@
 		<div class="navbar-collapse collapse justify-content-between" id="navbarToggler">
 			<ul class="navbar-nav">
 				<li class="nav-item"><a class="nav-link" href="/LatestChanges">@Localizer["menu_LatestChanges"]</a></li>
-				<li class="nav-item">
-					<a class="nav-link" href="/identity/UserAdmin">User Admin</a>
-				</li>
+				@if (User.Identity.IsAuthenticated)
+				{
+					if (User.IsInRole("Administrators"))
+					{
+						<li class="nav-item">
+							<a class="nav-link" href="/identity/UserAdmin">User Admin</a>
+						</li>
+					}
+				}
 				<li>
 					<form class="form-inline mx-0 mx-lg-2 my-2 my-lg-0" action="/search" method="get">
 						<div class="input-group">
@@ -82,21 +92,27 @@
 
 	<partial name="_CookieConsentPartial" />
 
-	<div class="container body-content">
-		@RenderBody()
-		<hr />
-		<footer>
-			<div class="row justify-content-between">
-				<div class="col-sm-12 col-md-8">
-					&copy; @DateTime.UtcNow.Year - <a target="_blank" href="https://github.com/csharpfritz/CoreWiki">@Localizer["CopyrightLinkText"]</a>
-				</div>
-				<div class="col-sm-12 col-md-auto">
-					<partial name="_ThemePartial" />
-				</div>
+<div class="container body-content">
+	@if (await UserManager.FindByEmailAsync("admin@corewiki.com") != null)
+	{
+		<div class="alert alert-danger" role="alert">
+			You still have the default administrator account enabled. Please create a new user with admin role and delete this account.
+		</div>
+	}
+	@RenderBody()
+	<hr/>
+	<footer>
+		<div class="row justify-content-between">
+			<div class="col-sm-12 col-md-8">
+				&copy; @DateTime.UtcNow.Year - <a target="_blank" href="https://github.com/csharpfritz/CoreWiki">@Localizer["CopyrightLinkText"]</a>
 			</div>
+			<div class="col-sm-12 col-md-auto">
+				<partial name="_ThemePartial"/>
+			</div>
+		</div>
 
-		</footer>
-	</div>
+	</footer>
+</div>
 
 	<script src="~/lib/moment/min/moment.min.js"></script>
 	<environment include="Development">

--- a/CoreWiki/Startup.cs
+++ b/CoreWiki/Startup.cs
@@ -1,8 +1,10 @@
-using CoreWiki.Configuration;
+using System.Threading.Tasks;
 using CoreWiki.Configuration.Startup;
 using CoreWiki.Core.Configuration;
+using CoreWiki.Data.Security;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -32,16 +34,16 @@ namespace CoreWiki
 		}
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-		public void Configure(IApplicationBuilder app, IHostingEnvironment env, IOptionsSnapshot<AppSettings> settings)
+		public async void Configure(IApplicationBuilder app, IHostingEnvironment env, IOptionsSnapshot<AppSettings> settings, UserManager<CoreWikiUser> userManager, RoleManager<IdentityRole> roleManager)
 		{
 			app.ConfigureTelemetry();
 			app.ConfigureExceptions(env);
 			app.ConfigureSecurityHeaders();
 			app.ConfigureRouting();
-			app.ConfigureAuthentication();
+			app.ConfigureDatabase();
+			await app.ConfigureAuthentication(userManager, roleManager);
 			app.ConfigureRSSFeed(settings);
 			app.ConfigureLocalisation();
-			app.ConfigureDatabase();
 
 			app.UseStatusCodePagesWithReExecute("/HttpErrors/{0}");
 			app.UseMvc();


### PR DESCRIPTION
- UserAdmin nav link to only be shown to authenticated users where they also have the Administrators RoleManager
- An admin can no longer assign or remove roles to themselves!
- On startup, check if Administrator role exists, if not create it, check if any users currently have administrators role, if not then create a default administrator account.
- Added warning to Layout if default admin account is found
- Refactor some of the AuthorizationPolicy 's to remove duplicate code.

Fixes issues for #247