### PR TITLE
Fixed the displayed 'Current page' number (#252)

### DIFF
--- a/CoreWiki.Test/Pages/SearchTests.cs
+++ b/CoreWiki.Test/Pages/SearchTests.cs
@@ -1,0 +1,38 @@
+﻿using CoreWiki.Data.Data.Interfaces;
+using CoreWiki.Data.Models;
+using CoreWiki.Pages;
+using CoreWiki.SearchEngines;
+using Moq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CoreWiki.Test.Pages
+{
+	public class SearchTests
+	{
+		[Fact]
+		public async Task OnGetAsync_WithPageNumberEqualsTo2And12Posts_ShouldReturnCurrentPageEqualsTo2()
+		{
+			var articleRepo = new Mock<IArticleRepository>();
+			var articleSearchEngine = new Mock<IArticlesSearchEngine>();
+
+			articleSearchEngine.Setup(o => o.SearchAsync("test", 2, 10)).Returns(
+				Task.FromResult(new SearchResult<Article>
+				{
+					CurrentPage = 2,
+					Results = new List<Article>
+					{
+						new Article { Slug = "test11" },
+						new Article { Slug = "test12" }
+					}
+				}));
+
+			var searchModel = new SearchModel(articleSearchEngine.Object, articleRepo.Object);
+
+			var result = await searchModel.OnGetAsync(query: "test", pageNumber: 2);
+
+			Assert.Equal(2, searchModel.SearchResult.CurrentPage);
+		}
+	}
+}

--- a/CoreWiki/Pages/Search.cshtml.cs
+++ b/CoreWiki/Pages/Search.cshtml.cs
@@ -48,7 +48,6 @@ namespace CoreWiki.Pages
 							ViewCount = article.ViewCount
 						}).ToList()
 				};
-				SearchResult.CurrentPage = 1;
 			}
 
 			return Page();


### PR DESCRIPTION
The current page number didn't update according to the current requested page. Removing the following line fixes it : `SearchResult.CurrentPage = 1;`

#Closes #252 