### PR TITLE
Prevent email notification being sent without user consent

### DIFF
--- a/CoreWiki.Notifications/NotificationService.cs
+++ b/CoreWiki.Notifications/NotificationService.cs
@@ -140,6 +140,7 @@ namespace CoreWiki.Notifications
 		    if (!canNotifyUser())
 		    {
 		        _logger.LogInformation("User has not consented to receiving emails, email not sent");
+				return false;
 		    }
 
             if (string.IsNullOrWhiteSpace(authorEmail))


### PR DESCRIPTION
Added a `return false;`statement to get out of the SendNewCommentEmail function when user didn't gave his consent for receiving notifications.

Closes #242 