### PR TITLE
Fixed EmailNotifications url configuration

### DIFF
--- a/CoreWiki.Notifications.Abstractions/Configuration/EmailNotifications.cs
+++ b/CoreWiki.Notifications.Abstractions/Configuration/EmailNotifications.cs
@@ -6,6 +6,5 @@
 		public string SendGridApiKey { get; set; }
 		public string FromEmailAddress { get; set; }
 		public string FromName { get; set; }
-		public string Url { get; set; }
 	}
 }

--- a/CoreWiki.Notifications/NotificationService.cs
+++ b/CoreWiki.Notifications/NotificationService.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using CoreWiki.Notifications.Models;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
-using CoreWiki.Notifications.Abstractions.Configuration;
 using CoreWiki.Notifications.Abstractions.Notifications;
 
 namespace CoreWiki.Notifications
@@ -14,20 +12,17 @@ namespace CoreWiki.Notifications
 		private readonly IEmailMessageFormatter _emailMessageFormatter;
 		private readonly IEmailNotifier _emailNotifier;
 		private readonly string _url;
-		private readonly EmailNotifications _appSettings;
 		private readonly ILogger<NotificationService> _logger;
 
 		public NotificationService(
 			IEmailMessageFormatter emailMessageFormatter,
 			IEmailNotifier emailNotifier,
-			IOptionsSnapshot<EmailNotifications> appSettings,
 			ILoggerFactory loggerFactory,
-			String Url)
+			string url)
 		{
 			_emailMessageFormatter = emailMessageFormatter;
 			_emailNotifier = emailNotifier;
-			_url = Url;
-			_appSettings = appSettings.Value;
+			_url = url;
 			_logger = loggerFactory.CreateLogger<NotificationService>();
 		}
 

--- a/CoreWiki.Notifications/NotificationService.cs
+++ b/CoreWiki.Notifications/NotificationService.cs
@@ -13,6 +13,7 @@ namespace CoreWiki.Notifications
 	{
 		private readonly IEmailMessageFormatter _emailMessageFormatter;
 		private readonly IEmailNotifier _emailNotifier;
+		private readonly string _url;
 		private readonly EmailNotifications _appSettings;
 		private readonly ILogger<NotificationService> _logger;
 
@@ -20,10 +21,12 @@ namespace CoreWiki.Notifications
 			IEmailMessageFormatter emailMessageFormatter,
 			IEmailNotifier emailNotifier,
 			IOptionsSnapshot<EmailNotifications> appSettings,
-			ILoggerFactory loggerFactory)
+			ILoggerFactory loggerFactory,
+			String Url)
 		{
 			_emailMessageFormatter = emailMessageFormatter;
 			_emailNotifier = emailNotifier;
+			_url = Url;
 			_appSettings = appSettings.Value;
 			_logger = loggerFactory.CreateLogger<NotificationService>();
 		}
@@ -56,9 +59,9 @@ namespace CoreWiki.Notifications
 				var encodedConfirmCode = UrlEncoder.Default.Encode(confirmCode);
 				var model = new ConfirmationEmailModel()
 				{
-					BaseUrl = _appSettings.Url.ToString(),
+					BaseUrl = _url,
 					Title = "CoreWiki Email Confirmation",
-					ReturnUrl = $"{_appSettings.Url}Identity/Account/ConfirmEmail?userId={userId}&code={encodedConfirmCode}",
+					ReturnUrl = $"{_url}Identity/Account/ConfirmEmail?userId={userId}&code={encodedConfirmCode}",
 					ConfirmEmail = confirmEmail
 				};
 
@@ -107,9 +110,9 @@ namespace CoreWiki.Notifications
 			{
 				var model = new ForgotPasswordEmailModel()
 				{
-					BaseUrl = _appSettings.Url.ToString(),
+					BaseUrl = _url,
 					Title = "CoreWiki Password Reset",
-					ReturnUrl = $"{_appSettings.Url}Identity/Account/ResetPassword?code={resetToken}",
+					ReturnUrl = $"{_url}Identity/Account/ResetPassword?code={resetToken}",
 					AccountEmail = accountEmail
 				};
 
@@ -135,68 +138,68 @@ namespace CoreWiki.Notifications
 
 		public async Task<bool> SendNewCommentEmail(string authorEmail, string authorName, string commenterName, string articleTopic, string articleSlug, Func<bool> canNotifyUser)
 		{
-		    _logger.LogInformation("Sending new comment email");
+			_logger.LogInformation("Sending new comment email");
 
-		    if (!canNotifyUser())
-		    {
-		        _logger.LogInformation("User has not consented to receiving emails, email not sent");
+			if (!canNotifyUser())
+			{
+				_logger.LogInformation("User has not consented to receiving emails, email not sent");
 				return false;
-		    }
+			}
 
-            if (string.IsNullOrWhiteSpace(authorEmail))
-		    {
-		        _logger.LogWarning("Missing parameter {Parameter}, new comment email not sent", nameof(authorEmail));
-                return false;
-		    }
+			if (string.IsNullOrWhiteSpace(authorEmail))
+			{
+				_logger.LogWarning("Missing parameter {Parameter}, new comment email not sent", nameof(authorEmail));
+				return false;
+			}
 
-		    if (string.IsNullOrWhiteSpace(authorName))
-		    {
-		        _logger.LogWarning("Missing parameter {Parameter}, new comment email not sent", nameof(authorName));
-                return false;
-		    }
+			if (string.IsNullOrWhiteSpace(authorName))
+			{
+				_logger.LogWarning("Missing parameter {Parameter}, new comment email not sent", nameof(authorName));
+				return false;
+			}
 
-		    if (string.IsNullOrWhiteSpace(commenterName))
-		    {
-		        _logger.LogWarning("Missing parameter {Parameter}, new comment email not sent", nameof(commenterName));
-                return false;
-		    }
+			if (string.IsNullOrWhiteSpace(commenterName))
+			{
+				_logger.LogWarning("Missing parameter {Parameter}, new comment email not sent", nameof(commenterName));
+				return false;
+			}
 
-		    if (string.IsNullOrWhiteSpace(articleTopic))
-		    {
-		        _logger.LogWarning("Missing parameter {Parameter}, new comment email not sent", nameof(articleTopic));
-                return false;
-		    }
+			if (string.IsNullOrWhiteSpace(articleTopic))
+			{
+				_logger.LogWarning("Missing parameter {Parameter}, new comment email not sent", nameof(articleTopic));
+				return false;
+			}
 
-		    if (string.IsNullOrWhiteSpace(articleSlug))
-		    {
-		        _logger.LogWarning("Missing parameter {Parameter}, new comment email not sent", nameof(articleSlug));
-                return false;
-		    }
+			if (string.IsNullOrWhiteSpace(articleSlug))
+			{
+				_logger.LogWarning("Missing parameter {Parameter}, new comment email not sent", nameof(articleSlug));
+				return false;
+			}
 
-		    try
-		    {
-		        var model = new NewCommentEmailModel()
-		        {
-		            BaseUrl = _appSettings.Url.ToString(),
-		            Title = "CoreWiki Notification",
-		            AuthorName = authorName,
-		            CommenterDisplayName = commenterName,
-		            ArticleTopic = articleTopic,
-		            ArticleUrl = $"{_appSettings.Url}{articleSlug}"
-		        };
+			try
+			{
+				var model = new NewCommentEmailModel()
+				{
+					BaseUrl = _url,
+					Title = "CoreWiki Notification",
+					AuthorName = authorName,
+					CommenterDisplayName = commenterName,
+					ArticleTopic = articleTopic,
+					ArticleUrl = $"{_url}{articleSlug}"
+				};
 
-                var messageBody = await _emailMessageFormatter.FormatEmailMessage(
-				    TemplateProvider.NewCommentEmailTemplate,
-				    model);
+				var messageBody = await _emailMessageFormatter.FormatEmailMessage(
+					TemplateProvider.NewCommentEmailTemplate,
+					model);
 
-			    return await _emailNotifier.SendEmailAsync(
-				    authorEmail,
-				    "Someone said something about your article",
-				    messageBody);
-		    }
-		    catch (Exception ex)
-		    {
-		        _logger.LogError(ex, ex.Message);
+				return await _emailNotifier.SendEmailAsync(
+					authorEmail,
+					"Someone said something about your article",
+					messageBody);
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(ex, ex.Message);
 #if DEBUG
 				throw;
 #else

--- a/CoreWiki.Notifications/StartupExtensions.cs
+++ b/CoreWiki.Notifications/StartupExtensions.cs
@@ -6,34 +6,50 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using System.Reflection;
 using CoreWiki.Notifications.Abstractions.Notifications;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
+using CoreWiki.Notifications.Abstractions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace CoreWiki.Notifications
 {
-    public static class StartupExtensions
+	public static class StartupExtensions
 	{
 
-		public static IServiceCollection AddEmailNotifications(this IServiceCollection services)
+		public static IServiceCollection AddEmailNotifications(this IServiceCollection services, IConfiguration configuration)
 		{
-		    services.AddHttpContextAccessor();
+			services.AddHttpContextAccessor();
 
-		    services.AddScoped<INotificationService, NotificationService>();
-		    services.AddScoped<IUrlHelper>(x =>
-		    {
-		        var actionContext = x.GetService<IActionContextAccessor>().ActionContext;
-		        return new UrlHelper(actionContext);
-		    });
+			services.AddScoped<INotificationService, NotificationService>();
+			services.AddScoped<IUrlHelper>(x =>
+			{
+				var actionContext = x.GetService<IActionContextAccessor>().ActionContext;
+				return new UrlHelper(actionContext);
+			});
 
-            services.AddScoped<ITemplateProvider, TemplateProvider>();
+			services.AddScoped<ITemplateProvider, TemplateProvider>();
 			services.AddScoped<ITemplateParser, TemplateParser>();
 			services.AddScoped<IEmailMessageFormatter, EmailMessageFormatter>();
 			services.AddScoped<IEmailNotifier, EmailNotifier>();
-		    services.AddScoped<INotificationService, NotificationService>();
+			services.AddScoped<INotificationService, NotificationService>(sp =>
+				{
+					var emailMessageFormatter = sp.GetService<IEmailMessageFormatter>();
+					var emailNotifier = sp.GetService<IEmailNotifier>();
+					var settings = sp.GetService<IOptionsSnapshot<EmailNotifications>>();
+					var loggerFactory = sp.GetService<ILoggerFactory>();
+					return new NotificationService(emailMessageFormatter,
+						emailNotifier,
+						settings,
+						loggerFactory,
+						configuration.GetSection("url").Value );
+				}
+			);
 
-		    services.Configure<RazorViewEngineOptions>(options =>
-		    {
-                options.FileProviders.Add(
-                    new EmbeddedFileProvider(typeof(TemplateProvider).GetTypeInfo().Assembly));
-		    });
+			services.Configure<RazorViewEngineOptions>(options =>
+			{
+				options.FileProviders.Add(
+					new EmbeddedFileProvider(typeof(TemplateProvider).GetTypeInfo().Assembly));
+			});
 			return services;
 
 		}

--- a/CoreWiki.Notifications/StartupExtensions.cs
+++ b/CoreWiki.Notifications/StartupExtensions.cs
@@ -7,8 +7,6 @@ using Microsoft.Extensions.FileProviders;
 using System.Reflection;
 using CoreWiki.Notifications.Abstractions.Notifications;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Options;
-using CoreWiki.Notifications.Abstractions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace CoreWiki.Notifications
@@ -20,7 +18,6 @@ namespace CoreWiki.Notifications
 		{
 			services.AddHttpContextAccessor();
 
-			services.AddScoped<INotificationService, NotificationService>();
 			services.AddScoped<IUrlHelper>(x =>
 			{
 				var actionContext = x.GetService<IActionContextAccessor>().ActionContext;
@@ -35,11 +32,9 @@ namespace CoreWiki.Notifications
 				{
 					var emailMessageFormatter = sp.GetService<IEmailMessageFormatter>();
 					var emailNotifier = sp.GetService<IEmailNotifier>();
-					var settings = sp.GetService<IOptionsSnapshot<EmailNotifications>>();
 					var loggerFactory = sp.GetService<ILoggerFactory>();
 					return new NotificationService(emailMessageFormatter,
 						emailNotifier,
-						settings,
 						loggerFactory,
 						configuration.GetSection("url").Value );
 				}
@@ -53,7 +48,5 @@ namespace CoreWiki.Notifications
 			return services;
 
 		}
-
-
 	}
 }

--- a/CoreWiki/Configuration/Startup/ConfigureScopedServices.cs
+++ b/CoreWiki/Configuration/Startup/ConfigureScopedServices.cs
@@ -2,6 +2,7 @@
 using CoreWiki.Application.Articles.Search.Impl;
 using CoreWiki.Notifications;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using NodaTime;
 using WebEssentials.AspNetCore.Pwa;
@@ -10,14 +11,14 @@ namespace CoreWiki.Configuration.Startup
 {
 	public static partial class ConfigurationExtensions
 	{
-		public static IServiceCollection ConfigureScopedServices(this IServiceCollection services)
+		public static IServiceCollection ConfigureScopedServices(this IServiceCollection services, IConfiguration configuration)
 		{
 			services.AddSingleton<IClock>(SystemClock.Instance);
 
 			services.AddHttpContextAccessor();
 			services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
-			services.AddEmailNotifications();
+			services.AddEmailNotifications(configuration);
 			services.AddScoped<IArticlesSearchEngine, ArticlesDbSearchEngine>();
 
 			services.AddProgressiveWebApp(new PwaOptions { EnableCspNonce = true });

--- a/CoreWiki/Startup.cs
+++ b/CoreWiki/Startup.cs
@@ -31,7 +31,7 @@ namespace CoreWiki
 			services.Configure<AppSettings>(Configuration);
 			services.ConfigureSecurityAndAuthentication();
 			services.ConfigureDatabase(Configuration);
-			services.ConfigureScopedServices();
+			services.ConfigureScopedServices(Configuration);
 			services.ConfigureRouting();
 			services.ConfigureLocalisation();
 			services.ConfigureApplicationServices();


### PR DESCRIPTION
The notification configuration got refactored and had an abstraction package introduced. However the notificationService also need to know what the url is in order to provide links in the email messages. They used to come directly from AppSettings. Due to the abstraction of the configuration, only the EmailNotification settings get injected, no longer the complete AppSettings (which makes sense). But now we're missing access to the URL of the website. So we inject that as a string as well to avoid a dependency on the CoreWiki website, directly. Such would introduce a circular dependency.

ASP.NET DI cannot handle string injection, so registering the service is done a bit more explicit.