### PR TITLE
Refactor search with dto

### DIFF
--- a/CoreWiki.Application/Articles/Search/Dto/SearchResultDto.cs
+++ b/CoreWiki.Application/Articles/Search/Dto/SearchResultDto.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CoreWiki.Application.Articles.Search.Dto
+{
+	public class SearchResultDto<T>
+	{
+		public string Query { get; set; }
+
+		public List<T> Results { get; set; }
+
+		public int TotalResults { get; set; }
+
+		public int ResultsPerPage { get; set; }
+
+		public int CurrentPage { get; set; }
+
+		public int TotalPages => (int)Math.Ceiling((decimal)TotalResults / ResultsPerPage);
+	}
+}

--- a/CoreWiki.Application/Articles/Search/Dto/SearchResultDto.cs
+++ b/CoreWiki.Application/Articles/Search/Dto/SearchResultDto.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace CoreWiki.Application.Articles.Search.Dto
 {
@@ -16,6 +14,6 @@ namespace CoreWiki.Application.Articles.Search.Dto
 
 		public int CurrentPage { get; set; }
 
-		public int TotalPages => (int)Math.Ceiling((decimal)TotalResults / ResultsPerPage);
+		public int TotalPages { get; set; }
 	}
 }

--- a/CoreWiki.Application/Articles/Search/IArticlesSearchEngine.cs
+++ b/CoreWiki.Application/Articles/Search/IArticlesSearchEngine.cs
@@ -6,6 +6,6 @@ namespace CoreWiki.Application.Articles.Search
 {
 	public interface IArticlesSearchEngine
 	{
-		Task<SearchResult<ArticleSearchDto>> SearchAsync(string query, int pageNumber, int resultsPerPage);
+		Task<SearchResultDto<ArticleSearchDto>> SearchAsync(string query, int pageNumber, int resultsPerPage);
 	}
 }

--- a/CoreWiki.Application/Articles/Search/Impl/ArticlesDbSearchEngine.cs
+++ b/CoreWiki.Application/Articles/Search/Impl/ArticlesDbSearchEngine.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using CoreWiki.Application.Articles.Search.Dto;
@@ -19,7 +20,7 @@ namespace CoreWiki.Application.Articles.Search.Impl
 			_mapper = mapper;
 		}
 
-		public async Task<SearchResult<ArticleSearchDto>> SearchAsync(string query, int pageNumber, int resultsPerPage)
+		public async Task<SearchResultDto<ArticleSearchDto>> SearchAsync(string query, int pageNumber, int resultsPerPage)
 		{
 			var filteredQuery = query.Trim();
 			var offset = (pageNumber - 1) * resultsPerPage;
@@ -28,14 +29,16 @@ namespace CoreWiki.Application.Articles.Search.Impl
 				_articleRepo.GetArticlesForSearchQuery(filteredQuery, offset, resultsPerPage);
 			var articles = searchQueryResult.articles;
 
-			return new SearchResult<ArticleSearchDto>
+			var result = new SearchResult<Article>
 			{
 				Query = filteredQuery,
-				Results = _mapper.Map<List<ArticleSearchDto>>(articles),
+				Results = articles.ToList(),
 				CurrentPage = pageNumber,
 				ResultsPerPage = resultsPerPage,
 				TotalResults = searchQueryResult.totalFound
 			};
+
+			return _mapper.Map<SearchResultDto<ArticleSearchDto>>(result);
 		}
 	}
 }

--- a/CoreWiki.Application/Articles/Search/Queries/SearchArticlesHandler.cs
+++ b/CoreWiki.Application/Articles/Search/Queries/SearchArticlesHandler.cs
@@ -1,12 +1,11 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using CoreWiki.Application.Articles.Search.Dto;
-using CoreWiki.Core.Domain;
 using MediatR;
 
 namespace CoreWiki.Application.Articles.Search.Queries
 {
-	class SearchArticlesHandler: IRequestHandler<SearchArticlesQuery, SearchResult<ArticleSearchDto>>
+	class SearchArticlesHandler: IRequestHandler<SearchArticlesQuery, SearchResultDto<ArticleSearchDto>>
 	{
 		private readonly IArticlesSearchEngine _articlesSearchEngine;
 
@@ -14,7 +13,7 @@ namespace CoreWiki.Application.Articles.Search.Queries
 		{
 			_articlesSearchEngine = articlesSearchEngine;
 		}
-		public Task<SearchResult<ArticleSearchDto>> Handle(SearchArticlesQuery request, CancellationToken cancellationToken)
+		public Task<SearchResultDto<ArticleSearchDto>> Handle(SearchArticlesQuery request, CancellationToken cancellationToken)
 		{
 			return _articlesSearchEngine.SearchAsync(request.Query, request.PageNumber, request.ResultsPerPage);
 		}

--- a/CoreWiki.Application/Articles/Search/Queries/SearchArticlesQuery.cs
+++ b/CoreWiki.Application/Articles/Search/Queries/SearchArticlesQuery.cs
@@ -1,10 +1,9 @@
 ﻿using CoreWiki.Application.Articles.Search.Dto;
-using CoreWiki.Core.Domain;
 using MediatR;
 
 namespace CoreWiki.Application.Articles.Search.Queries
 {
-	public class SearchArticlesQuery: IRequest<SearchResult<ArticleSearchDto>>
+	public class SearchArticlesQuery: IRequest<SearchResultDto<ArticleSearchDto>>
 	{
 		public string Query { get; }
 		public int PageNumber { get; }

--- a/CoreWiki.Test/Pages/SearchTests.cs
+++ b/CoreWiki.Test/Pages/SearchTests.cs
@@ -1,8 +1,5 @@
-﻿using CoreWiki.Application.Articles.Search;
-using CoreWiki.Application.Articles.Search.Dto;
+﻿using CoreWiki.Application.Articles.Search.Dto;
 using CoreWiki.Application.Articles.Search.Queries;
-using CoreWiki.Core.Domain;
-using CoreWiki.Data.Abstractions.Interfaces;
 using CoreWiki.Pages;
 using MediatR;
 using Moq;
@@ -22,7 +19,7 @@ namespace CoreWiki.Test.Pages
 			var mediator = new Mock<IMediator>();
 
 			mediator.Setup(o => o.Send(It.IsAny<SearchArticlesQuery>(), default(CancellationToken))).Returns(
-				Task.FromResult(new SearchResult<ArticleSearchDto>
+				Task.FromResult(new SearchResultDto<ArticleSearchDto>
 				{
 					CurrentPage = 2,
 					Results = new List<ArticleSearchDto>

--- a/CoreWiki/CoreWiki.csproj
+++ b/CoreWiki/CoreWiki.csproj
@@ -33,7 +33,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CoreWiki.Application\CoreWiki.Application.csproj" />
-    <ProjectReference Include="..\CoreWiki.Core\CoreWiki.Core.csproj" />
     <ProjectReference Include="..\CoreWiki.Notifications\CoreWiki.Notifications.csproj" />
 		<ProjectReference Include="..\CoreWiki.Data\CoreWiki.Data.EntityFramework.csproj" />
   </ItemGroup>

--- a/CoreWiki/Pages/Search.cshtml.cs
+++ b/CoreWiki/Pages/Search.cshtml.cs
@@ -1,10 +1,10 @@
-using CoreWiki.Core.Domain;
 using CoreWiki.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using System.Linq;
 using System.Threading.Tasks;
 using CoreWiki.Application.Articles.Reading.Queries;
+using CoreWiki.Application.Articles.Search.Dto;
 using CoreWiki.Application.Articles.Search.Queries;
 using MediatR;
 
@@ -13,7 +13,7 @@ namespace CoreWiki.Pages
 	public class SearchModel : PageModel
 	{
 		private readonly IMediator _mediator;
-		public SearchResult<ArticleSummary> SearchResult;
+		public SearchResultDto<ArticleSummary> SearchResult;
 		private const int ResultsPerPage = 10;
 
 		public SearchModel(IMediator mediator)
@@ -35,7 +35,7 @@ namespace CoreWiki.Pages
 			var result = await _mediator.Send(qry);
 
 			//todo: use automapper
-			SearchResult = new SearchResult<ArticleSummary>
+			SearchResult = new SearchResultDto<ArticleSummary>
 			{
 				Query = result.Query,
 				TotalResults = result.TotalResults,
@@ -60,7 +60,7 @@ namespace CoreWiki.Pages
 			var qry = new GetLatestArticlesQuery(10);
 			var results = await _mediator.Send(qry);
 
-			SearchResult = new SearchResult<ArticleSummary>
+			SearchResult = new SearchResultDto<ArticleSummary>
 			{
 				Results = (from article in results
 									 select new ArticleSummary

--- a/CoreWiki/ViewModels/Comment.cs
+++ b/CoreWiki/ViewModels/Comment.cs
@@ -1,6 +1,4 @@
-﻿using CoreWiki.Core.Domain;
-using NodaTime;
-using System;
+﻿using NodaTime;
 
 namespace CoreWiki.ViewModels
 {


### PR DESCRIPTION
The search page was still using a domain object `SearchResult` directly, so I refactored the search application to return a `SearchResultDto` instead. 