### PR TITLE
Added Azure Pipelines build definition

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,63 @@
+variables:
+  DOTNET_SDK_VERSION: '2.1.401'
+
+jobs:
+- job: MacOS
+  displayName: Build on MacOs
+
+  pool:
+    vmImage: 'macOS 10.13'
+
+  steps:
+  - task: DotNetCoreInstaller@0
+    displayName: 'Use .NET Core SDK $(DOTNET_SDK_VERSION)'
+    inputs:
+      version: '$(DOTNET_SDK_VERSION)'
+
+  - bash: ./build.sh
+    displayName: 'Execute Cake Boostrapper'
+
+
+- job: Windows
+  displayName: Build on Windows
+
+  pool:
+    vmImage: 'VS2017-Win2016'
+
+  steps:
+  - task: DotNetCoreInstaller@0
+    displayName: 'Use .NET Core SDK $(DOTNET_SDK_VERSION)'
+    inputs:
+      version: '$(DOTNET_SDK_VERSION)'
+
+
+  - powershell: ./build.ps1
+    displayName: 'Execute Cake PowerShell Boostrapper'
+
+
+- job: Linux
+  displayName: Build on Linux
+
+  pool:
+    vmImage: 'Ubuntu 16.04'
+
+  steps:
+  - task: DotNetCoreInstaller@0
+    displayName: 'Use .NET Core SDK $(DOTNET_SDK_VERSION)'
+    inputs:
+      version: '$(DOTNET_SDK_VERSION)'
+
+
+  - bash: ./build.sh
+    displayName: 'Execute Cake Bash Boostrapper'
+
+
+- job: Docker
+  displayName: Build Docker Image
+
+  pool:
+    vmImage: 'Ubuntu 16.04'
+
+  steps:
+  - task: Docker@1
+    displayName: 'Build image'


### PR DESCRIPTION
[![Build Status](https://dev.azure.com/devleadse/CoreWiki/_apis/build/status/devlead.CoreWiki)](https://dev.azure.com/devleadse/CoreWiki/_build/latest?definitionId=1)

* Adds azure-pipelines.yml = Azure Pipelines yaml build definition, with phases for
  - Building on hosted MacOS Agent
  - Building on hosted Windows Agent
  - Building on hosted Linux Agent
  - Building Docker container on hosted Linux Agent

For build definition to be used it needs to  be merged into default branch first (in CoreWiki's case `dev` branch), so PR needs to be merged first otherwise new pipeline guide won't pick it up.

But you can see it in action on my fork at
https://dev.azure.com/devleadse/CoreWiki/_build/results?buildId=5&view=logs

