### PR TITLE
Added macOS and Linux specific files to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -279,3 +279,38 @@ CoreWiki/wwwroot/lib/
 
 # Ignore test results
 test_result.xml
+
+# mac OS specifc files
+# Based but simplified:  https://github.com/github/gitignore/blob/master/Global/macOS.gitignore
+## General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+## Thumbnails
+._*
+
+## Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Linux specific files
+# Based on: https://github.com/github/gitignore/blob/master/Global/Linux.gitignore
+*~
+
+## Temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+## KDE directory preferences
+.directory
+
+## Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+## .nfs files are created when an open file is removed but is still being accessed
+.nfs*


### PR DESCRIPTION
Closes #301

This is a very tiny contribution but maybe this will show how easy it is to start contributing to open source projects AND that dotnet Core is no longer an evil thing for non Windows-based developers.

It would great if you could do an Live Stream that shows how to work with CoreWiki on a macOS or Linux system? That would be so great!

Thanks for bringen this awesome community together! 

Greetings from Germany
- Tobias (Tobonautilus from the Chat)