### PR TITLE
Handler code cleanup with tests

### DIFF
--- a/CoreWiki.Application/Articles/Managing/Commands/CreateNewArticleCommandHandler.cs
+++ b/CoreWiki.Application/Articles/Managing/Commands/CreateNewArticleCommandHandler.cs
@@ -22,20 +22,17 @@ namespace CoreWiki.Application.Articles.Managing.Commands
 
 		public async Task<CommandResult> Handle(CreateNewArticleCommand request, CancellationToken cancellationToken)
 		{
-			var result = new CommandResult() { Successful = true };
-
 			try
 			{
 				var article = _mapper.Map<Article>(request);
 				await _articleManagementService.CreateArticleAndHistory(article);
+
+				return CommandResult.Success();
 			}
 			catch (Exception ex)
 			{
-				result.Successful = false;
-				result.Exception = new CreateArticleException("There was an error creating the article", ex);
+				return CommandResult.Error(new CreateArticleException("There was an error creating the article", ex));
 			}
-			return result;
-
 		}
 
 	}

--- a/CoreWiki.Application/Articles/Managing/Commands/DeleteArticleCommandHandler.cs
+++ b/CoreWiki.Application/Articles/Managing/Commands/DeleteArticleCommandHandler.cs
@@ -18,19 +18,15 @@ namespace CoreWiki.Application.Articles.Managing.Commands
 
 		public async Task<CommandResult> Handle(DeleteArticleCommand request, CancellationToken cancellationToken)
 		{
-			var result = new CommandResult() { Successful = true };
-
 			try
 			{
 				await _articleManagementService.Delete(request.Slug);
+				return CommandResult.Success();
 			}
 			catch (Exception ex)
 			{
-				result.Successful = false;
-				result.Exception = new DeleteArticleException("There was an error deleting the article", ex);
+				return CommandResult.Error(new DeleteArticleException("There was an error deleting the article", ex));
 			}
-
-			return result;
 		}
 	}
 }

--- a/CoreWiki.Application/Articles/Managing/Commands/EditArticleCommand.cs
+++ b/CoreWiki.Application/Articles/Managing/Commands/EditArticleCommand.cs
@@ -7,11 +7,11 @@ namespace CoreWiki.Application.Articles.Managing.Commands
 	public class EditArticleCommand : IRequest<CommandResult>
 	{
 
-		public int Id { get; private set; }
-		public string Topic { get; private set; }
-		public string Content { get; private set; }
-		public Guid AuthorId { get; private set; }
-		public string AuthorName { get; private set; }
+		public int Id { get; set; }
+		public string Topic { get; set; }
+		public string Content { get; set; }
+		public Guid AuthorId { get; set; }
+		public string AuthorName { get; set; }
 
 		//public EditArticleCommand()
 		//{

--- a/CoreWiki.Application/Articles/Managing/Commands/EditArticleCommandHandler.cs
+++ b/CoreWiki.Application/Articles/Managing/Commands/EditArticleCommandHandler.cs
@@ -8,7 +8,6 @@ namespace CoreWiki.Application.Articles.Managing.Commands
 {
 	public class EditArticleCommandHandler : IRequestHandler<EditArticleCommand, CommandResult>
 	{
-
 		private readonly IArticleManagementService _articleManagementService;
 
 		public EditArticleCommandHandler(IArticleManagementService articleManagementService)
@@ -18,17 +17,15 @@ namespace CoreWiki.Application.Articles.Managing.Commands
 
 		public async Task<CommandResult> Handle(EditArticleCommand request, CancellationToken cancellationToken)
 		{
-			var result = new CommandResult { Successful = false };
 			try
 			{
 				await _articleManagementService.Update(request.Id, request.Topic, request.Content, request.AuthorId, request.AuthorName);
-				result.Successful = true;
-				return result;
+				
+				return CommandResult.Success();
 			}
 			catch (Exception ex)
 			{
-				result.Exception = ex;
-				return result;
+				return CommandResult.Error(ex);
 			}
 		}
 	}

--- a/CoreWiki.Application/Articles/Reading/Commands/CreateNewCommentCommandHandler.cs
+++ b/CoreWiki.Application/Articles/Reading/Commands/CreateNewCommentCommandHandler.cs
@@ -22,21 +22,17 @@ namespace CoreWiki.Application.Articles.Reading.Commands
 
 		public async Task<CommandResult> Handle(CreateNewCommentCommand request, CancellationToken cancellationToken)
 		{
-			var result = new CommandResult() { Successful = true };
-
 			try
 			{
 				var comment = _mapper.Map<CreateCommentDto>(request);
 				await _articleReadingService.CreateComment(comment);
+
+				return CommandResult.Success();
 			}
 			catch (Exception ex)
 			{
-				result.Successful = false;
-				result.Exception = new CreateCommentException("There was an error creating the comment", ex);
+				return CommandResult.Error(new CreateCommentException("There was an error creating the comment", ex));
 			}
-
-			return result;
-
 		}
 	}
 }

--- a/CoreWiki.Application/Common/CommandResult.cs
+++ b/CoreWiki.Application/Common/CommandResult.cs
@@ -4,11 +4,18 @@ namespace CoreWiki.Application.Common
 {
 	public class CommandResult
 	{
-
 		public bool Successful { get; set; }
 
 		public Exception Exception { get; set; }
 
+		public static CommandResult Success()
+		{
+			return new CommandResult {Successful = true};
+		}
 
+		public static CommandResult Error(Exception exception)
+		{
+			return new CommandResult {Successful = false, Exception = exception};
+		}
 	}
 }

--- a/CoreWiki.Test/Application/Managing/Commands/CreateNewArticleCommandHandlerTests.cs
+++ b/CoreWiki.Test/Application/Managing/Commands/CreateNewArticleCommandHandlerTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using CoreWiki.Application.Articles.Managing;
+using CoreWiki.Application.Articles.Managing.Commands;
+using CoreWiki.Core.Domain;
+using Moq;
+using Xunit;
+
+namespace CoreWiki.Test.Application.Managing.Commands
+{
+	public class CreateNewArticleCommandHandlerTests
+	{
+		private readonly CreateNewArticleCommandHandler _createNewArticleCommandHandler;
+		private readonly IMapper _mapper;
+		private readonly IArticleManagementService _articleManagementService;
+		private readonly CreateNewArticleCommand _createNewArticleCommand;
+		private readonly Article _article;
+
+		public CreateNewArticleCommandHandlerTests()
+		{
+			_mapper = Mock.Of<IMapper>();
+			_articleManagementService = Mock.Of<IArticleManagementService>();
+			_createNewArticleCommandHandler = new CreateNewArticleCommandHandler(_articleManagementService, _mapper);
+
+			_createNewArticleCommand = new CreateNewArticleCommand();
+			_article = new Article();
+
+			Mock.Get(_mapper).Setup(m => m.Map<Article>(_createNewArticleCommand)).Returns(_article);
+		}
+
+		[Fact]
+		public async Task Handle_HappyPath_Successful()
+		{
+			var result = await _createNewArticleCommandHandler.Handle(_createNewArticleCommand, CancellationToken.None);
+
+			Mock.Get(_articleManagementService).Verify(s => s.CreateArticleAndHistory(_article));
+			Assert.True(result.Successful);
+		}
+
+		[Fact]
+		public async Task Error_MapThrows_UnsuccessfulWithException()
+		{
+			var exception = new Exception();
+			Mock.Get(_mapper).Setup(s => s.Map<Article>(_createNewArticleCommand)).Throws(exception);
+
+			var handle = await _createNewArticleCommandHandler.Handle(_createNewArticleCommand, CancellationToken.None);
+
+			Assert.False(handle.Successful);
+			Assert.Equal("There was an error creating the article", handle.Exception.Message);
+			Assert.Same(handle.Exception.InnerException, exception);
+		}
+
+		[Fact]
+		public async Task Error_CreateArticleAndHistoryThrows_UnsuccessfulWithException()
+		{
+			var exception = new Exception();			
+			Mock.Get(_articleManagementService).Setup(s => s.CreateArticleAndHistory(_article)).Throws(exception);
+
+			var handle = await _createNewArticleCommandHandler.Handle(_createNewArticleCommand, CancellationToken.None);
+
+			Assert.False(handle.Successful);
+			Assert.Equal("There was an error creating the article", handle.Exception.Message);
+			Assert.Same(exception, handle.Exception.InnerException);
+		}
+	}
+}

--- a/CoreWiki.Test/Application/Managing/Commands/CreateNewCommentCommandHandlerTests.cs
+++ b/CoreWiki.Test/Application/Managing/Commands/CreateNewCommentCommandHandlerTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using CoreWiki.Application.Articles.Reading;
+using CoreWiki.Application.Articles.Reading.Commands;
+using CoreWiki.Application.Articles.Reading.Dto;
+using Moq;
+using Xunit;
+
+namespace CoreWiki.Test.Application.Managing.Commands
+{
+	public class CreateNewCommentCommandHandlerTests
+	{
+		private readonly CreateNewCommentCommandHandler _createNewCommentCommandHandler;
+		private readonly IArticleReadingService _articleReadingService;
+		private readonly IMapper _mapper;
+		private readonly CreateNewCommentCommand _createNewCommentCommand;
+		private readonly CreateCommentDto _createCommentDto;
+
+		public CreateNewCommentCommandHandlerTests()
+		{
+			_articleReadingService = Mock.Of<IArticleReadingService>();
+			_mapper = Mock.Of<IMapper>();
+			_createNewCommentCommandHandler = new CreateNewCommentCommandHandler(_articleReadingService, _mapper);
+
+			_createNewCommentCommand = new CreateNewCommentCommand();
+			_createCommentDto = new CreateCommentDto();
+			Mock.Get(_mapper).Setup(m => m.Map<CreateCommentDto>(_createNewCommentCommand)).Returns(_createCommentDto);
+
+		}
+
+		[Fact]
+		public async Task Handle_HappyPath_SuccessfulResult()
+		{
+			var result = await _createNewCommentCommandHandler.Handle(_createNewCommentCommand, CancellationToken.None);
+
+			Mock.Get(_articleReadingService).Verify(s => s.CreateComment(_createCommentDto));
+			Assert.True(result.Successful);
+		}
+
+		[Fact]
+		public async Task Handle_ArticleReadingServiceThrows_UnsuccessfulWithException()
+		{
+			var exception = new Exception();
+			Mock.Get(_articleReadingService).Setup(s => s.CreateComment(_createCommentDto)).Throws(exception);
+
+			var result = await _createNewCommentCommandHandler.Handle(_createNewCommentCommand, CancellationToken.None);
+
+			Assert.False(result.Successful);
+			Assert.Same(exception, result.Exception.InnerException);
+			Assert.Matches("There was an error creating the comment", result.Exception.Message);
+		}
+
+		[Fact]
+		public async Task Handle_MappingThrows_UnsuccessfulWithException()
+		{
+			var exception = new Exception();
+			Mock.Get(_mapper).Setup(m => m.Map<CreateCommentDto>(_createNewCommentCommand)).Throws(exception);
+
+			var result = await _createNewCommentCommandHandler.Handle(_createNewCommentCommand, CancellationToken.None);
+
+			Assert.False(result.Successful);
+			Assert.Same(exception, result.Exception.InnerException);
+			Assert.Matches("There was an error creating the comment", result.Exception.Message);
+		}
+
+	}
+}

--- a/CoreWiki.Test/Application/Managing/Commands/DeleteArticleCommandHandlerTests.cs
+++ b/CoreWiki.Test/Application/Managing/Commands/DeleteArticleCommandHandlerTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CoreWiki.Application.Articles.Managing;
+using CoreWiki.Application.Articles.Managing.Commands;
+using Moq;
+using Xunit;
+
+namespace CoreWiki.Test.Application.Managing.Commands
+{
+	public class DeleteArticleCommandHandlerTests
+	{
+		private readonly DeleteArticleCommandHandler _deleteArticleCommandHandler;
+		private readonly IArticleManagementService _articleManagementService;
+		private readonly DeleteArticleCommand _deleteArticleCommand;
+
+		private const string SomeSlug = "some slug";
+
+		public DeleteArticleCommandHandlerTests()
+		{
+			_articleManagementService = Mock.Of<IArticleManagementService>();
+			_deleteArticleCommandHandler = new DeleteArticleCommandHandler(_articleManagementService);
+
+			_deleteArticleCommand = new DeleteArticleCommand(SomeSlug);
+		}
+
+		[Fact]
+		public async Task Handle_HappyPath_Successful()
+		{
+			var result = await _deleteArticleCommandHandler.Handle(_deleteArticleCommand, CancellationToken.None);
+
+			Mock.Get(_articleManagementService).Verify(s => s.Delete(SomeSlug));
+			Assert.True(result.Successful);
+		}
+
+		[Fact]
+		public async Task Handle_ArticleManagementServiceThrows_UnsuccessfulWithException()
+		{
+			var exception = new Exception();
+			Mock.Get(_articleManagementService).Setup(s => s.Delete(SomeSlug)).Throws(exception);
+
+			var result = await _deleteArticleCommandHandler.Handle(_deleteArticleCommand, CancellationToken.None);
+
+			Assert.False(result.Successful);
+			Assert.Matches("There was an error deleting the article", result.Exception.Message);
+			Assert.Same(exception, result.Exception.InnerException);
+		}
+	}
+}

--- a/CoreWiki.Test/Application/Managing/Commands/EditArticleCommandHandlerTests.cs
+++ b/CoreWiki.Test/Application/Managing/Commands/EditArticleCommandHandlerTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CoreWiki.Application.Articles.Managing;
+using CoreWiki.Application.Articles.Managing.Commands;
+using Moq;
+using Xunit;
+
+namespace CoreWiki.Test.Application.Managing.Commands
+{
+	public class EditArticleCommandHandlerTests
+	{
+		private readonly EditArticleCommandHandler _articleCommandHandler;
+		private readonly IArticleManagementService _articleManagementService;
+		private readonly EditArticleCommand _editArticleCommand;
+
+		public EditArticleCommandHandlerTests()
+		{
+			_articleManagementService = Mock.Of<IArticleManagementService>();
+			_articleCommandHandler = new EditArticleCommandHandler(_articleManagementService);
+
+			_editArticleCommand = new EditArticleCommand
+			{
+				AuthorId = Guid.NewGuid(),
+				AuthorName = "Author Name",
+				Content = "Some content",
+				Id = 123,
+				Topic = "Some topic"
+			};
+		}
+
+		[Fact]
+		public async Task Handle_HappyPath_Successful()
+		{
+			var result = await _articleCommandHandler.Handle(_editArticleCommand, CancellationToken.None);
+
+			Mock.Get(_articleManagementService).Verify(s => s.Update(_editArticleCommand.Id, _editArticleCommand.Topic, _editArticleCommand.Content,_editArticleCommand.AuthorId, _editArticleCommand.AuthorName));
+			Assert.True(result.Successful);
+		}
+
+		[Fact]
+		public async Task Handle_ArticleManagementServiceThrows_UnsuccessfulWithException()
+		{
+			var exception = new Exception();
+			Mock.Get(_articleManagementService).Setup(s => s.Update(_editArticleCommand.Id, _editArticleCommand.Topic, _editArticleCommand.Content, _editArticleCommand.AuthorId, _editArticleCommand.AuthorName))
+				.Throws(exception);
+
+			var result = await _articleCommandHandler.Handle(_editArticleCommand, CancellationToken.None);
+
+			Assert.False(result.Successful);
+			Assert.Same(exception, result.Exception);
+		}
+	}
+}


### PR DESCRIPTION
Hi,

I've added a couple static methods to CommandResult for the success and error cases to cleanup the usages from the handler code. I also added unit tests around the changes.