### PR TITLE
Removed redundant reference to fontawesome

### DIFF
--- a/CoreWiki/Pages/Shared/_Layout.cshtml
+++ b/CoreWiki/Pages/Shared/_Layout.cshtml
@@ -146,9 +146,7 @@
 				crossorigin="anonymous"></script>
 		<script src="~/js/site.min.js" asp-append-version="true"></script>
 	</environment>
-
-	<script defer src="https://use.fontawesome.com/releases/v5.2.0/js/all.js" integrity="sha384-4oV5EgaV02iISL2ban6c/RmotsABqE4yZxZLcYMAdG7FAPsyHYAPpywE9PJo+Khy" crossorigin="anonymous"></script>
-
+	
 	@RenderSection("Scripts", required: false)
 </body>
 </html>


### PR DESCRIPTION
We are setting this right above so no need to this one more time here

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/csharpfritz/corewiki/305)
<!-- Reviewable:end -->
