### PR TITLE
Added vscode workspace with files.exclude for typical vs temp paths

### DIFF
--- a/CoreWiki.code-workspace
+++ b/CoreWiki.code-workspace
@@ -1,0 +1,21 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+        "files.exclude": {
+            "**/.cr/": true,
+            "**/.vs/": true,
+            "**/obj/": true,
+            "**/bin/": true,
+            "**/packages/": true,
+            "**/node_modules/": true,
+            "**/*.csproj.user": true,
+            "**/*.js.map": true,
+            "**/*.js": {"when": "$(basename).ts"},
+            "**/TestResults/": true
+        },
+    }
+}


### PR DESCRIPTION
This should hide the obj and bin and other folders you don't want cluttering up your vscode explorer pane.