### PR TITLE
Deduplicate URLFriendly

### DIFF
--- a/CoreWiki.Application/Articles/Managing/Impl/ArticleManagementService.cs
+++ b/CoreWiki.Application/Articles/Managing/Impl/ArticleManagementService.cs
@@ -46,13 +46,13 @@ namespace CoreWiki.Application.Articles.Managing.Impl
 
 		public async Task<Article> Update(int id, string topic, string content, Guid authorId, string authorName)
 		{
-			var slug = UrlHelpers.URLFriendly(topic);
-			if (string.IsNullOrWhiteSpace(slug))
+			var article = new Article { Topic = topic };
+			if (string.IsNullOrWhiteSpace(article.Slug))
 			{
 				throw new InvalidTopicException("The topic must contain at least one alphanumeric character.");
 			}
 
-			var existingArticle = await _repository.GetArticleBySlug(slug);
+			var existingArticle = await _repository.GetArticleBySlug(article.Slug);
 			if (existingArticle != null && existingArticle.Id != id)
 			{
 				throw new InvalidTopicException("The topic conflicts with an existing article.");
@@ -67,7 +67,6 @@ namespace CoreWiki.Application.Articles.Managing.Impl
 
 			var oldSlug = existingArticle.Slug;
 			existingArticle.Topic = topic;
-			existingArticle.Slug = UrlHelpers.URLFriendly(topic);
 			existingArticle.Content = content;
 			existingArticle.AuthorId = authorId;
 			existingArticle.AuthorName = authorName;

--- a/CoreWiki.Application/Articles/Managing/Queries/GetArticleHandler.cs
+++ b/CoreWiki.Application/Articles/Managing/Queries/GetArticleHandler.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using CoreWiki.Application.Articles.Managing.Dto;
 using CoreWiki.Application.Common;
+using CoreWiki.Core.Domain;
 using MediatR;
 
 namespace CoreWiki.Application.Articles.Managing.Queries
@@ -18,8 +19,8 @@ namespace CoreWiki.Application.Articles.Managing.Queries
 
 		public Task<bool> Handle(GetIsTopicAvailableQuery request, CancellationToken cancellationToken)
 		{
-			var slug = UrlHelpers.URLFriendly(request.Topic);
-			return _service.IsTopicAvailable(slug, request.ArticleId);
+			var article = new Article { Topic = request.Topic };
+			return _service.IsTopicAvailable(article.Slug, request.ArticleId);
 		}
 
 		public Task<ArticleManageDto> Handle(GetArticleQuery request, CancellationToken cancellationToken)

--- a/CoreWiki.Application/Common/UrlHelpers.cs
+++ b/CoreWiki.Application/Common/UrlHelpers.cs
@@ -1,63 +1,12 @@
-﻿using System;
-using System.Globalization;
-using System.Text;
-using System.Text.RegularExpressions;
+﻿using System.Globalization;
 
 namespace CoreWiki.Application.Common
 {
 	public class UrlHelpers
 	{
-
-		private static readonly Regex reSlugCharactersToBeDashes = new Regex(@"([\s,.//\\-_=])+");
-		private static readonly Regex reSlugCharactersToRemove = new Regex(@"([^0-9a-z\-])+");
-		private static readonly Regex reSlugDashes = new Regex(@"([\-])+");
-
-		private static readonly Regex reSlugCharacters = new Regex(@"([\s,.//\\-_=])+");
-
-		internal static string URLFriendly(string title)
-		{
-
-			if (String.IsNullOrEmpty(title)) return "";
-
-
-			var newTitle = RemoveDiacritics(title);
-
-			newTitle = Regex.Replace(newTitle, "(?<!^)([A-Z][a-z]|(?<=[a-z])[A-Z])", @"-$1");
-
-			newTitle = reSlugCharactersToBeDashes.Replace(newTitle, "-");
-
-			newTitle = newTitle.ToLowerInvariant();
-
-			newTitle = reSlugCharactersToRemove.Replace(newTitle, "");
-
-			newTitle = reSlugDashes.Replace(newTitle, "-");
-
-			newTitle = newTitle.Trim('-');
-
-			return newTitle;
-
-		}
-
-		static string RemoveDiacritics(string text)
-		{
-			var normalizedString = text.Normalize(NormalizationForm.FormD);
-			var stringBuilder = new StringBuilder();
-
-			foreach (var c in normalizedString)
-			{
-				var unicodeCategory = CharUnicodeInfo.GetUnicodeCategory(c);
-				if (unicodeCategory != UnicodeCategory.NonSpacingMark)
-				{
-					stringBuilder.Append(c);
-				}
-			}
-
-			return stringBuilder.ToString().Normalize(NormalizationForm.FormC);
-		}
-
 		public static string SlugToTopic(string slug)
 		{
-			if (String.IsNullOrEmpty(slug))
+			if (string.IsNullOrEmpty(slug))
 			{
 				return "";
 			}
@@ -66,7 +15,6 @@ namespace CoreWiki.Application.Common
 			var outValue = textInfo.ToTitleCase(slug);
 
 			return outValue.Replace("-", " ");
-
 		}
 	}
 }

--- a/CoreWiki.Core/Domain/Article.cs
+++ b/CoreWiki.Core/Domain/Article.cs
@@ -9,14 +9,16 @@ namespace CoreWiki.Core.Domain
 {
 	public class Article
 	{
-
 		public int Id { get; set; }
 
-		public string Topic { get
+		public string Topic
+		{
+			get
 			{
 				return _Topic;
 			}
-			set {
+			set
+			{
 				Slug = URLFriendly(value);
 				_Topic = value;
 			}
@@ -24,8 +26,7 @@ namespace CoreWiki.Core.Domain
 
 		private string _Topic;
 
-		public string Slug { get; set; }
-
+		public string Slug { get; private set; }
 
 		public int Version { get; set; } = 1;
 
@@ -57,11 +58,9 @@ namespace CoreWiki.Core.Domain
 
 		private static readonly Regex reSlugCharacters = new Regex(@"([\s,.//\\-_=])+");
 
-		public string URLFriendly(string title)
+		private static string URLFriendly(string title)
 		{
-
 			if (string.IsNullOrEmpty(title)) return "";
-
 
 			var newTitle = RemoveDiacritics(title);
 
@@ -78,7 +77,6 @@ namespace CoreWiki.Core.Domain
 			newTitle = newTitle.Trim('-');
 
 			return newTitle;
-
 		}
 
 		static string RemoveDiacritics(string text)
@@ -100,7 +98,7 @@ namespace CoreWiki.Core.Domain
 
 		public static string SlugToTopic(string slug)
 		{
-			if (String.IsNullOrEmpty(slug))
+			if (string.IsNullOrEmpty(slug))
 			{
 				return "";
 			}
@@ -109,9 +107,6 @@ namespace CoreWiki.Core.Domain
 			var outValue = textInfo.ToTitleCase(slug);
 
 			return outValue.Replace("-", " ");
-
 		}
-
 	}
-
 }

--- a/CoreWiki.Data/Models/ArticleDAO.cs
+++ b/CoreWiki.Data/Models/ArticleDAO.cs
@@ -100,7 +100,6 @@ namespace CoreWiki.Data.EntityFramework.Models
 				History = History.Select(h => h.ToDomain()).ToHashSet(),
 				Id = Id,
 				Published = Published,
-				Slug = Slug,
 				Topic = Topic,
 				Version = Version,
 				ViewCount = ViewCount

--- a/CoreWiki.Test/Core/Domain/ArticleTests.cs
+++ b/CoreWiki.Test/Core/Domain/ArticleTests.cs
@@ -1,0 +1,22 @@
+using CoreWiki.Core.Domain;
+using Xunit;
+
+namespace CoreWiki.Test.Core.Domain
+{
+	public class ArticleTests
+	{
+		[Theory]
+		[InlineData("HomePage", "home-page")]
+		public void SettingTopic_ShouldGenerateValidSlug(string topic, string expectedSlug)
+		{
+			// Arrange
+			var sut = new Article();
+
+			// Act
+			sut.Topic = topic;
+
+			// Assert
+			Assert.Equal(expectedSlug, sut.Slug);
+		}
+	}
+}

--- a/CoreWiki.Test/Helpers/UrlHelperTests.cs
+++ b/CoreWiki.Test/Helpers/UrlHelperTests.cs
@@ -18,23 +18,5 @@ namespace CoreWiki.Test.Helpers
 			var actual_topic = UrlHelpers.SlugToTopic(slug);
 			Assert.Equal(expected_topic, actual_topic);
 		}
-
-		[Theory]
-		[InlineData("OneTwo", "one-two")]
-		[InlineData("HomePage", "home-page")]
-		public void ShouldAddDashBetweenWords(string givenText, string expectedUrlFriendly)
-		{
-
-			// act
-			var result = UrlHelpers.URLFriendly(givenText);
-
-			// assert
-			Assert.Equal(expectedUrlFriendly, result);
-
-
-		}
-
-
-
 	}
 }


### PR DESCRIPTION
Fixes #313

Next step would be to remove the UrlHelpers class entirely.

Things to note about this PR:
- Merging into project_FirstStart since this is where @csharpfritz commit changes regarding this issue
- Build is currently broken by default