### PR TITLE
Set explicit version for Microsoft.AspNetCore.App in Test Project to fix build errors

### DIFF
--- a/CoreWiki.Test/CoreWiki.Test.csproj
+++ b/CoreWiki.Test/CoreWiki.Test.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="xunit" Version="2.4.0" />


### PR DESCRIPTION
This PR should fix the Build Errors you were having on the last stream after setting an implicit version.

There are two workarounds at the moment:
1. Change the test project's <Project> tag in the first line to use the web SDK (Microsoft.NET.Sdk.Web instead of Microsoft.NET.Sdk) and add a package reference to Microsoft.AspNetCore.App (or .All if you are using that inside the web project) without specifying a version
2. Leave the Sdk as-is and add a PackageReference to the shared framework package but specify a version.

This PR uses the second workaround.

@natemcmaster if you have time could you elaborate on the reason why exactly it is required and what the future plan is?

More details and discussions:

[https://github.com/aspnet/AspNetCore/issues/3307](https://github.com/aspnet/AspNetCore/issues/3307)

[https://stackoverflow.com/questions/50401152/integration-and-unit-tests-no-longer-work-on-asp-net-core-2-1-failing-to-find-as/50401153#50401153](https://stackoverflow.com/questions/50401152/integration-and-unit-tests-no-longer-work-on-asp-net-core-2-1-failing-to-find-as/50401153#50401153)
