### PR TITLE
Default article rename bugfix

### DIFF
--- a/CoreWiki.Application/Articles/Managing/Dto/ArticleManageDto.cs
+++ b/CoreWiki.Application/Articles/Managing/Dto/ArticleManageDto.cs
@@ -5,6 +5,7 @@ namespace CoreWiki.Application.Articles.Managing.Dto
 {
 	public class ArticleManageDto
 	{
+		public bool IsHomePage { get; set; }
 		public string Content { get; set; }
 		public int Id { get; set; }
 		public string Slug { get; set; }

--- a/CoreWiki.Application/Articles/Reading/Dto/ArticleReadingDto.cs
+++ b/CoreWiki.Application/Articles/Reading/Dto/ArticleReadingDto.cs
@@ -5,6 +5,7 @@ namespace CoreWiki.Application.Articles.Reading.Dto
 {
 	public class ArticleReadingDto
 	{
+		public bool IsHomePage { get; set; }
 		public string Content { get; set; }
 		public int Id { get; set; }
 		public string Slug { get; set; }

--- a/CoreWiki.Application/Articles/Search/Dto/ArticleSearchDto.cs
+++ b/CoreWiki.Application/Articles/Search/Dto/ArticleSearchDto.cs
@@ -5,6 +5,7 @@ namespace CoreWiki.Application.Articles.Search.Dto
 {
 	public class ArticleSearchDto
 	{
+		public bool IsHomePage { get; set; }
 		public string Content { get; set; }
 		public int Id { get; set; }
 		public string Slug { get; set; }

--- a/CoreWiki.Core/Domain/Article.cs
+++ b/CoreWiki.Core/Domain/Article.cs
@@ -37,6 +37,8 @@ namespace CoreWiki.Core.Domain
 
 		public string Content { get; set; }
 
+		public bool IsHomePage => Id == 1;
+
 		public virtual ICollection<Comment> Comments { get; set; }
 
 		public virtual ICollection<ArticleHistory> History { get; set; }

--- a/CoreWiki.Data/ApplicationDbContext.cs
+++ b/CoreWiki.Data/ApplicationDbContext.cs
@@ -23,7 +23,7 @@ namespace CoreWiki.Data.EntityFramework
 				Id = 1,
 				Topic = "Home Page",
 				Slug = "home-page",
-				Content = "This is the default home page.  Please change me!",
+				Content = "This is the default home page. Please change me!",
 				Published = Instant.FromDateTimeUtc(new DateTime(2018, 6, 19, 14, 31, 2, 265, DateTimeKind.Utc)),
 				AuthorId = Guid.Empty
 			};

--- a/CoreWiki.FirstStart/StartupExtensions.cs
+++ b/CoreWiki.FirstStart/StartupExtensions.cs
@@ -36,7 +36,7 @@ namespace CoreWiki.FirstStart
 
 		private static bool IsFirstStartIncomplete(HttpContext context)
 		{
-			return true;
+			return false;
 		}
 	}
 

--- a/CoreWiki.Test/Pages/SearchTests.cs
+++ b/CoreWiki.Test/Pages/SearchTests.cs
@@ -1,5 +1,6 @@
 ﻿using CoreWiki.Application.Articles.Search.Dto;
 using CoreWiki.Application.Articles.Search.Queries;
+using CoreWiki.Configuration.Startup;
 using CoreWiki.Pages;
 using MediatR;
 using Moq;
@@ -30,7 +31,7 @@ namespace CoreWiki.Test.Pages
 				}));
 
 			// Act
-			var searchModel = new SearchModel(mediator.Object);
+			var searchModel = new SearchModel(mediator.Object, ConfigureAutomapperServices.ConfigureAutomapper(null));
 
 			var result = await searchModel.OnGetAsync(query: "test", pageNumber: 2);
 

--- a/CoreWiki/Configuration/Startup/CoreWikiWebsiteProfile.cs
+++ b/CoreWiki/Configuration/Startup/CoreWikiWebsiteProfile.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using AutoMapper;
 using CoreWiki.Application.Articles.Managing.Commands;
 using CoreWiki.Application.Articles.Reading.Commands;
 using CoreWiki.Application.Articles.Reading.Dto;
+using CoreWiki.Application.Articles.Search.Dto;
 using CoreWiki.Application.Common;
 using CoreWiki.ViewModels;
 
@@ -37,6 +39,10 @@ namespace CoreWiki.Configuration.Startup
 			CreateMap<ClaimsPrincipal, EditArticleCommand>(MemberList.None)
 				.ForMember(d => d.AuthorId, m => m.MapFrom(s => Guid.Parse(s.FindFirstValue(ClaimTypes.NameIdentifier))))
 				.ForMember(d => d.AuthorName, m => m.MapFrom(s => s.Identity.Name));
+
+			CreateMap<IList<ArticleReadingDto>, SearchResultDto<ArticleSummary>>(MemberList.None)
+				.ForMember(d => d.Results, m => m.MapFrom(s => s))
+				.ForMember(d => d.TotalResults, m => m.MapFrom(s => s.Count));
 		}
 	}
 }

--- a/CoreWiki/Pages/Delete.cshtml.cs
+++ b/CoreWiki/Pages/Delete.cshtml.cs
@@ -44,7 +44,7 @@ namespace CoreWiki.Pages
 				return NotFound();
 			}
 
-			if (article.Slug == UrlHelpers.HomePageSlug)
+			if (article.IsHomePage)
 			{
 				await _mediator.Publish(new DeleteHomePageAttemptNotification());
 				return Forbid();

--- a/CoreWiki/Pages/Details.cshtml
+++ b/CoreWiki/Pages/Details.cshtml
@@ -42,7 +42,7 @@
 	<div>
 		<a asp-page="/Edit" asp-route-slug="@Model.Article.Slug" asp-policy="@PolicyConstants.CanEditArticles" class="btn btn-outline-info">@Localizer["Edit"]</a>
 
-		@if (!Model.IsHomePage)
+		@if (!Model.Article.IsHomePage)
 		{
 			<a href="~/" class="btn btn-secondary">@Localizer["GoHome"]</a>
 		}

--- a/CoreWiki/Pages/Details.cshtml
+++ b/CoreWiki/Pages/Details.cshtml
@@ -42,7 +42,7 @@
 	<div>
 		<a asp-page="/Edit" asp-route-slug="@Model.Article.Slug" asp-policy="@PolicyConstants.CanEditArticles" class="btn btn-outline-info">@Localizer["Edit"]</a>
 
-		@if (Model.Article.Slug != UrlHelpers.HomePageSlug)
+		@if (!Model.IsHomePage)
 		{
 			<a href="~/" class="btn btn-secondary">@Localizer["GoHome"]</a>
 		}

--- a/CoreWiki/Pages/Details.cshtml.cs
+++ b/CoreWiki/Pages/Details.cshtml.cs
@@ -26,7 +26,9 @@ namespace CoreWiki.Pages
 
 		public ArticleDetails Article { get; set; }
 
-		[ViewDataAttribute]
+		public bool IsHomePage => Article.Id == 1;
+
+		[ViewData]
 		public string Slug { get; set; }
 
 		public async Task<IActionResult> OnGetAsync(string slug)

--- a/CoreWiki/Pages/Details.cshtml.cs
+++ b/CoreWiki/Pages/Details.cshtml.cs
@@ -26,8 +26,6 @@ namespace CoreWiki.Pages
 
 		public ArticleDetails Article { get; set; }
 
-		public bool IsHomePage => Article.Id == 1;
-
 		[ViewData]
 		public string Slug { get; set; }
 

--- a/CoreWiki/Pages/Search.cshtml.cs
+++ b/CoreWiki/Pages/Search.cshtml.cs
@@ -1,24 +1,26 @@
 using CoreWiki.ViewModels;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using System.Linq;
 using System.Threading.Tasks;
 using CoreWiki.Application.Articles.Reading.Queries;
 using CoreWiki.Application.Articles.Search.Dto;
 using CoreWiki.Application.Articles.Search.Queries;
 using MediatR;
+using AutoMapper;
 
 namespace CoreWiki.Pages
 {
 	public class SearchModel : PageModel
 	{
 		private readonly IMediator _mediator;
+		private readonly IMapper _mapper;
 		public SearchResultDto<ArticleSummary> SearchResult;
 		private const int ResultsPerPage = 10;
 
-		public SearchModel(IMediator mediator)
+		public SearchModel(IMediator mediator, IMapper mapper)
 		{
 			_mediator = mediator;
+			_mapper = mapper;
 		}
 
 		public string RequestedPage => Request.Path.Value.ToLowerInvariant().Substring(1);
@@ -29,29 +31,10 @@ namespace CoreWiki.Pages
 			{
 				return Page();
 			}
-			var qry = new SearchArticlesQuery(query,
-				pageNumber,
-				ResultsPerPage);
+			var qry = new SearchArticlesQuery(query, pageNumber, ResultsPerPage);
 			var result = await _mediator.Send(qry);
 
-			//todo: use automapper
-			SearchResult = new SearchResultDto<ArticleSummary>
-			{
-				Query = result.Query,
-				TotalResults = result.TotalResults,
-				ResultsPerPage = result.ResultsPerPage,
-				CurrentPage = result.CurrentPage,
-				Results = (from article in result.Results
-					select new ArticleSummary
-					{
-						IsHomePage = article.IsHomePage,
-						Slug = article.Slug,
-						Topic = article.Topic,
-						Published = article.Published,
-						ViewCount = article.ViewCount
-					}).ToList()
-			};
-			//SearchResult.CurrentPage = 1;
+			SearchResult = _mapper.Map<SearchResultDto<ArticleSummary>>(result);
 
 			return Page();
 		}
@@ -61,21 +44,10 @@ namespace CoreWiki.Pages
 			var qry = new GetLatestArticlesQuery(10);
 			var results = await _mediator.Send(qry);
 
-			SearchResult = new SearchResultDto<ArticleSummary>
-			{
-				Results = (from article in results
-									 select new ArticleSummary
-									 {
-										 IsHomePage = article.IsHomePage,
-										 Slug = article.Slug,
-										 Topic = article.Topic,
-										 Published = article.Published,
-										 ViewCount = article.ViewCount
-									 }).ToList(),
-				ResultsPerPage = 11,
-				CurrentPage = 1
-			};
-			SearchResult.TotalResults = SearchResult.Results.Count;
+			SearchResult = _mapper.Map<SearchResultDto<ArticleSummary>>(results);
+			SearchResult.ResultsPerPage = 11;
+			SearchResult.CurrentPage = 1;
+
 			return Page();
 		}
 	}

--- a/CoreWiki/Pages/Search.cshtml.cs
+++ b/CoreWiki/Pages/Search.cshtml.cs
@@ -44,6 +44,7 @@ namespace CoreWiki.Pages
 				Results = (from article in result.Results
 					select new ArticleSummary
 					{
+						IsHomePage = article.IsHomePage,
 						Slug = article.Slug,
 						Topic = article.Topic,
 						Published = article.Published,
@@ -65,6 +66,7 @@ namespace CoreWiki.Pages
 				Results = (from article in results
 									 select new ArticleSummary
 									 {
+										 IsHomePage = article.IsHomePage,
 										 Slug = article.Slug,
 										 Topic = article.Topic,
 										 Published = article.Published,

--- a/CoreWiki/Pages/_ArticleRow.cshtml
+++ b/CoreWiki/Pages/_ArticleRow.cshtml
@@ -16,7 +16,7 @@
 			<h6 class="card-subtitle mb-2 text-muted">@Localizer["ViewCount"]: <span> @Model.ViewCount</span></h6>
 
 			<a class="card-link btn btn-outline-info btn-sm" asp-page="/Edit" asp-route-slug="@Model.Slug">@Localizer["Edit"]</a>
-			@if (Model.Slug != UrlHelpers.HomePageSlug)
+			@if (!Model.IsHomePage)
 			{
 				<a class="card-link btn btn-outline-danger btn-sm" asp-policy="CanDeleteArticles" asp-policy-message="You do not have permission to delete this article." asp-page="/Delete" asp-route-slug="@Model.Slug">@Localizer["Delete"]</a>
 			}

--- a/CoreWiki/ViewModels/ArticleDetails.cs
+++ b/CoreWiki/ViewModels/ArticleDetails.cs
@@ -6,6 +6,7 @@ namespace CoreWiki.ViewModels
 {
 	public class ArticleDetails
 	{
+		public bool IsHomePage { get; set; }
 		public int Id { get; set; }
 		public Guid AuthorId { get; set; }
 		public string Slug { get; set; }

--- a/CoreWiki/ViewModels/ArticleSummary.cs
+++ b/CoreWiki/ViewModels/ArticleSummary.cs
@@ -4,6 +4,7 @@ namespace CoreWiki.ViewModels
 {
 	public class ArticleSummary
 	{
+		public bool IsHomePage { get; set; }
 		public string Slug { get; set; }
 		public string Topic { get; set; }
 		public Instant Published { get; set; }


### PR DESCRIPTION
### The issue
To my understanding, the default article is special to CoreWiki - it serves as a home page, and cannot be deleted.

However, it can be renamed, and this causes unwanted functionality to be revealed.
- A _Back to home_ button appears when you're already on the home page
- The _Delete_ button appears, enabling the admin to delete this special article, causing CoreWiki home page to return 404

### The cause
The reason for this bug is that we're performing a slug check against a C# constant 'home-page', but the actual slug changes when the topic is modified.

Furthermore, this same check is **duplicated** across Pages and PageModels.

### Proposed solution
The concept that an article is a default home page is something specific to our domain, so I have added an IsHomePage property to our Domain Article. For the time being it returns true if the article id is 1, which resolves the issues of 'Back to home' and 'Delete' buttons appearing when they should not.

In addition, by adding an IsHomePage property to the necessary Dtos, and letting AutoMapper take care of the rest, we are enabling ourselves to control the logic of identifying the default article in a single place - the domain object. 🎉