### PR TITLE
UI improvements in Details and Comments

### DIFF
--- a/CoreWiki/Pages/Components/CreateComments/CreateComments.cshtml
+++ b/CoreWiki/Pages/Components/CreateComments/CreateComments.cshtml
@@ -1,7 +1,6 @@
 ﻿@model ViewModels.Comment
-<br />
-<br />
-<div class="card card-header">
+
+<div class="card card-header mt-4">
 	<h5>@Localizer["NewComment"]</h5>
 	<form method="post" autocomplete="off">
 		<input type="hidden" asp-for="@Model.ArticleId" />

--- a/CoreWiki/Pages/Components/CreateComments/CreateComments.cshtml
+++ b/CoreWiki/Pages/Components/CreateComments/CreateComments.cshtml
@@ -4,36 +4,34 @@
 	<h5>@Localizer["NewComment"]</h5>
 	<form method="post" autocomplete="off">
 		<input type="hidden" asp-for="@Model.ArticleId" />
-		<div class="container-fluid">
-			<div class="row">
-				<div class="col-sm">
-					<div class="form-group">
-						<label asp-for="@Model.DisplayName" class="control-label"></label>
-						<input asp-for="@Model.DisplayName" class="form-control" />
-						<span asp-validation-for="@Model.DisplayName" class="text-danger"></span>
-					</div>
-				</div>
-				<div class="col-sm">
-					<div class="form-group">
-						<label asp-for="@Model.Email" class="control-label"></label>
-						<input asp-for="@Model.Email" class="form-control" />
-						<span asp-validation-for="@Model.Email" class="text-danger"></span>
-					</div>
-				</div>
-			</div>
-			<div class="row">
-				<div class="col-sm">
-					<div class="form-group">
-						<label asp-for="@Model.Content" class="control-label"></label>
-						<textarea asp-for="@Model.Content" class="form-control"></textarea>
-						<span asp-validation-for="@Model.Content" class="text-danger"></span>
-					</div>
-				</div>
-			</div>
-			<div class="row">
+		<div class="row">
+			<div class="col-sm">
 				<div class="form-group">
-					<input type="submit" value=@Localizer["Submit"] class="btn btn-outline-primary" />
+					<label asp-for="@Model.DisplayName" class="control-label"></label>
+					<input asp-for="@Model.DisplayName" class="form-control" />
+					<span asp-validation-for="@Model.DisplayName" class="text-danger"></span>
 				</div>
+			</div>
+			<div class="col-sm">
+				<div class="form-group">
+					<label asp-for="@Model.Email" class="control-label"></label>
+					<input asp-for="@Model.Email" class="form-control" />
+					<span asp-validation-for="@Model.Email" class="text-danger"></span>
+				</div>
+			</div>
+		</div>
+		<div class="row">
+			<div class="col-sm">
+				<div class="form-group">
+					<label asp-for="@Model.Content" class="control-label"></label>
+					<textarea asp-for="@Model.Content" class="form-control"></textarea>
+					<span asp-validation-for="@Model.Content" class="text-danger"></span>
+				</div>
+			</div>
+		</div>
+		<div class="row">
+			<div class="form-group col">
+				<input type="submit" value=@Localizer["Submit"] class="btn btn-outline-primary" />
 			</div>
 		</div>
 	</form>

--- a/CoreWiki/Pages/Details.cshtml
+++ b/CoreWiki/Pages/Details.cshtml
@@ -33,20 +33,18 @@
 	</div>
 </div>
 <br />
-<div class="container">
-	<markdown markdown="Article.Content" />
+<markdown markdown="Article.Content" />
 
-	<div>
-		<a asp-page="/Edit" asp-route-slug="@Model.Article.Slug" asp-policy="@PolicyConstants.CanEditArticles" class="btn btn-outline-info">@Localizer["Edit"]</a>
+<div>
+	<a asp-page="/Edit" asp-route-slug="@Model.Article.Slug" asp-policy="@PolicyConstants.CanEditArticles" class="btn btn-outline-info">@Localizer["Edit"]</a>
 
-		@if (!Model.Article.IsHomePage)
-		{
-			<a href="~/" class="btn btn-secondary">@Localizer["GoHome"]</a>
-		}
-	</div>
-
-	<partial name="_CommentsPartial" model="Model" />
+	@if (!Model.Article.IsHomePage)
+	{
+		<a href="~/" class="btn btn-secondary">@Localizer["GoHome"]</a>
+	}
 </div>
+
+<partial name="_CommentsPartial" model="Model" />
 @section Scripts {
 	@await Html.PartialAsync("_EditorScript")
 	<script type="text/javascript">

--- a/CoreWiki/Pages/Details.cshtml
+++ b/CoreWiki/Pages/Details.cshtml
@@ -14,22 +14,20 @@
 }
 
 <div class="card card-header">
-	<div class="container">
-		<div class="row">
-			<div id="topicContainer" class="col-xl-7 col-lg-8 col-md-12">
-				<h2 id="topic">@Model.Article.Topic</h2>
+	<div class="row">
+		<div id="topicContainer" class="col-xl-7 col-lg-8 col-md-12">
+			<h2 id="topic">@Model.Article.Topic</h2>
+		</div>
+		<div class="col-xl-5 col-lg-4 col-md-12">
+			<div class="row">
+				<div class="col-xl-12 small text-muted">@Localizer["Published"]: <span data-value="@Model.Article.Published" class="timeStampValue"> @Model.Article.Published</span></div>
 			</div>
-			<div class="col-xl-5 col-lg-4 col-md-12">
-				<div class="row">
-					<div class="col-xl-12 small text-muted">@Localizer["Published"]: <span data-value="@Model.Article.Published" class="timeStampValue"> @Model.Article.Published</span></div>
-				</div>
-				<div class="row">
-					<div class="col-xl-4 small"><span class="text-muted">@Localizer["ViewCount"]: </span><span class="badge badge-primary" data-value="@Model.Article.ViewCount"> @Model.Article.ViewCount</span></div>
-					<div class="col-xl-8 small"><span class="text-muted">@Localizer["ReadingTime"]: </span><span class="badge badge-primary duration" data-duration="@Model.Article.Content.CalculateReadTime().TotalMilliseconds"></span></div>
-				</div>
-				<div class="row">
-					<div class="col-xl-12 small"><a asp-page="History" asp-route-slug="@Model.Article.Slug">@string.Format(Localizer["HistoryFormat"].Value, Model.Article.Version)</a></div>
-				</div>
+			<div class="row">
+				<div class="col-xl-4 small"><span class="text-muted">@Localizer["ViewCount"]: </span><span class="badge badge-primary" data-value="@Model.Article.ViewCount"> @Model.Article.ViewCount</span></div>
+				<div class="col-xl-8 small"><span class="text-muted">@Localizer["ReadingTime"]: </span><span class="badge badge-primary duration" data-duration="@Model.Article.Content.CalculateReadTime().TotalMilliseconds"></span></div>
+			</div>
+			<div class="row">
+				<div class="col-xl-12 small"><a asp-page="History" asp-route-slug="@Model.Article.Slug">@string.Format(Localizer["HistoryFormat"].Value, Model.Article.Version)</a></div>
 			</div>
 		</div>
 	</div>

--- a/CoreWiki/Pages/Details.cshtml
+++ b/CoreWiki/Pages/Details.cshtml
@@ -13,7 +13,7 @@
 	}
 }
 
-<div class="card card-header">
+<div class="card card-header mb-3">
 	<div class="row">
 		<div id="topicContainer" class="col-xl-7 col-lg-8 col-md-12">
 			<h2 id="topic">@Model.Article.Topic</h2>
@@ -32,7 +32,7 @@
 		</div>
 	</div>
 </div>
-<br />
+
 <markdown markdown="Article.Content" />
 
 <div>

--- a/CoreWiki/Pages/Details.cshtml
+++ b/CoreWiki/Pages/Details.cshtml
@@ -16,22 +16,19 @@
 <div class="card card-header">
 	<div class="container">
 		<div class="row">
-			<div id="topicContainer" style="width: 500px">
-				<h2 id="topic" class="col-xl-7 col-lg-8 col-md-12">@Model.Article.Topic</h2>
+			<div id="topicContainer" class="col-xl-7 col-lg-8 col-md-12">
+				<h2 id="topic">@Model.Article.Topic</h2>
 			</div>
 			<div class="col-xl-5 col-lg-4 col-md-12">
-				<div class="container">
-					<div class="row">
-						<div class="col-xl-12 small text-muted">@Localizer["Published"]: <span data-value="@Model.Article.Published" class="timeStampValue"> @Model.Article.Published</span></div>
-
-					</div>
-					<div class="row">
-						<div class="col-xl-4 small"><span class="text-muted">@Localizer["ViewCount"]: </span><span class="badge badge-primary" data-value="@Model.Article.ViewCount"> @Model.Article.ViewCount</span></div>
-						<div class="col-xl-8 small"><span class="text-muted">@Localizer["ReadingTime"]: </span><span class="badge badge-primary duration" data-duration="@Model.Article.Content.CalculateReadTime().TotalMilliseconds"></span></div>
-					</div>
-					<div class="row">
-						<div class="col-xl-12 small"><a asp-page="History" asp-route-slug="@Model.Article.Slug">@string.Format(Localizer["HistoryFormat"].Value, Model.Article.Version)</a></div>
-					</div>
+				<div class="row">
+					<div class="col-xl-12 small text-muted">@Localizer["Published"]: <span data-value="@Model.Article.Published" class="timeStampValue"> @Model.Article.Published</span></div>
+				</div>
+				<div class="row">
+					<div class="col-xl-4 small"><span class="text-muted">@Localizer["ViewCount"]: </span><span class="badge badge-primary" data-value="@Model.Article.ViewCount"> @Model.Article.ViewCount</span></div>
+					<div class="col-xl-8 small"><span class="text-muted">@Localizer["ReadingTime"]: </span><span class="badge badge-primary duration" data-duration="@Model.Article.Content.CalculateReadTime().TotalMilliseconds"></span></div>
+				</div>
+				<div class="row">
+					<div class="col-xl-12 small"><a asp-page="History" asp-route-slug="@Model.Article.Slug">@string.Format(Localizer["HistoryFormat"].Value, Model.Article.Version)</a></div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
### Changes
- Remove extra nested bootstrap containers, since the page is already wrapped in a container. This frees more room for content, which is much needed on mobile screens.
- Normalise alignment of different elements and sections.
- Replace `<br>` elements for margins.

### Preview
>**Desktop article header before**
![before-desktop](https://user-images.githubusercontent.com/15656341/48300794-b4649580-e4e3-11e8-9e34-b844de897b68.PNG)

>**Desktop article header after**
![after-desktop](https://user-images.githubusercontent.com/15656341/48300804-bdedfd80-e4e3-11e8-8c02-60d80cd1d075.PNG)

>**Mobile article header before**
![before-mobile](https://user-images.githubusercontent.com/15656341/48300806-c34b4800-e4e3-11e8-985f-38733f6caf67.PNG)

>**Mobile article header after**
![after-mobile](https://user-images.githubusercontent.com/15656341/48300808-c80ffc00-e4e3-11e8-8d45-ef25986d423a.PNG)

>**Mobile article content and comments before**
![mobile-before-2](https://user-images.githubusercontent.com/15656341/48301308-46709c00-e4ec-11e8-9ad6-455a68454adf.PNG)

>**Mobile article content and comments after**
![mobile-after-2](https://user-images.githubusercontent.com/15656341/48301310-4b355000-e4ec-11e8-83bb-b6c81edd8813.PNG)