### PR TITLE
Uncomment and fix admin seeding & fix user manager

### DIFF
--- a/CoreWiki.Data/Security/SeedDefaultAdminUser.cs
+++ b/CoreWiki.Data/Security/SeedDefaultAdminUser.cs
@@ -10,7 +10,8 @@ namespace CoreWiki.Data.EntityFramework.Security
 		public static async Task Seed(UserManager<CoreWikiUser> userManager, RoleManager<IdentityRole> roleManager)
 		{
 			var administratorsRole = "Administrators";
-			var defaultAdminUsername = "admin@corewiki.com";
+			var defaultAdminUsername = "admin";
+			var defaultAdminEmail = "admin@corewiki.com";
 			var defaultAdminPassword = "Admin@123";
 
 			var adminRoleExists = await roleManager.RoleExistsAsync(administratorsRole);
@@ -26,28 +27,28 @@ namespace CoreWiki.Data.EntityFramework.Security
 			}
 
 			// If there are no users who are currently an admin, then create a default admin user
-			// var anyAdminUsers = await userManager.GetUsersInRoleAsync(administratorsRole);
+			var anyAdminUsers = await userManager.GetUsersInRoleAsync(administratorsRole);
 
-			// if (!anyAdminUsers.Any())
-			// {
-			// 	var defaultAdminUserExists = await userManager.FindByEmailAsync(defaultAdminUsername);
+			if (!anyAdminUsers.Any())
+			{
+				var defaultAdminUserExists = await userManager.FindByNameAsync(defaultAdminUsername);
 
-			// 	if (defaultAdminUserExists == null)
-			// 	{
-			// 		var defaultAdminUser = new CoreWikiUser
-			// 		{
-			// 			UserName = defaultAdminUsername,
-			// 			Email = defaultAdminUsername
-			// 		};
+				if (defaultAdminUserExists == null)
+				{
+					var defaultAdminUser = new CoreWikiUser
+					{
+						UserName = defaultAdminUsername,
+						Email = defaultAdminEmail
+					};
 
-			// 		var userResult = await userManager.CreateAsync(defaultAdminUser, defaultAdminPassword);
+					var userResult = await userManager.CreateAsync(defaultAdminUser, defaultAdminPassword);
 
-			// 		if (userResult.Succeeded)
-			// 		{
-			// 			var result = await userManager.AddToRoleAsync(defaultAdminUser, administratorsRole);
-			// 		}
-			// 	}
-			// }
+					if (userResult.Succeeded)
+					{
+						var result = await userManager.AddToRoleAsync(defaultAdminUser, administratorsRole);
+					}
+				}
+			}
 		}
 	}
 }

--- a/CoreWiki/Areas/Identity/Pages/UserAdmin/Index.cshtml.cs
+++ b/CoreWiki/Areas/Identity/Pages/UserAdmin/Index.cshtml.cs
@@ -52,7 +52,7 @@ namespace CoreWiki.Areas.Identity.Pages.UserAdmin
 				return Page();
 			}
 
-			var user = await UserManager.FindByEmailAsync(UsernameToAddRoleTo);
+			var user = await UserManager.FindByNameAsync(UsernameToAddRoleTo);
 
 			if (user == null)
 			{


### PR DESCRIPTION
Hi @csharpfritz 

@codeTherapist and me tried to run the CoreWiki live on Twitch and had troubles to login with the admin user. Live on Twitch we debugged CoreWiki and found out the the seeding of the admin user was commented out and didn't work.

After un-commenting the code we code the message that an email address cannot be used as a username so we changed the username to just "admin" instead of the email address.

because of this change we also needed to change the user administration, because the OnPostUpdateUserRolesAsync tries to find the user by username using the FindByEmailAsync method instead. This doesn't work anymore because of our previous fix.

Was there a reason to comment the seeding of the admin user? If not our PR would help to get the seeding working again and it is easier to get the Wiki working.

Cheers
Juergen and @codeTherapist